### PR TITLE
Store mac-vendor-lookup cache in data dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY README.md .
 
 RUN pip install --no-cache-dir -e .
 
-# Create data directory for database
+# Create data directory for database and cache
 RUN mkdir -p /data && chown bluehood:bluehood /data
 
 # Environment variables

--- a/bluehood/scanner.py
+++ b/bluehood/scanner.py
@@ -13,7 +13,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
 try:
-    from mac_vendor_lookup import AsyncMacLookup, MacLookup
+    from mac_vendor_lookup import AsyncMacLookup, MacLookup, BaseMacLookup
     HAS_MAC_LOOKUP = True
 except ImportError:
     HAS_MAC_LOOKUP = False
@@ -21,9 +21,13 @@ except ImportError:
 # Online API for vendor lookup fallback
 MACVENDORS_API_URL = "https://api.macvendors.com/"
 
-from .config import SCAN_DURATION, BLUETOOTH_ADAPTER
+from .config import SCAN_DURATION, BLUETOOTH_ADAPTER, DATA_DIR
 
 logger = logging.getLogger(__name__)
+
+# Configure mac-vendor-lookup to use BLUEHOOD_DATA_DIR for caching
+if HAS_MAC_LOOKUP:
+    BaseMacLookup.cache_path = str(DATA_DIR / "mac-vendors.txt")
 
 
 # Bluetooth device class codes for classification


### PR DESCRIPTION
When running in docker the default mac-vendor-cache folder ~/.cache does not exist in the container and therefore nothing from the mac vendor lookup is cached. This PR changes that and stores the mac-vendors.txt file created by the mac-vendor-lookup library into the data dir (See https://github.com/bauerj/mac_vendor_lookup/blob/master/README.md about how to define the cache location)