### PR TITLE
Fix inability to update MAC vendor database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN pip install --no-cache-dir -e .
 # Create data directory for database
 RUN mkdir -p /data && chown bluehood:bluehood /data
 
+# Create directory for mac addresses cache
+RUN mkdir -p /home/bluehood/.cache \
+    && chown bluehood:bluehood /home/bluehood/.cache
+
 # Environment variables
 ENV BLUEHOOD_DATA_DIR=/data
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
Hello!

During deployment with Docker compose the following warnings were in the logs:

```bash
bluehood  | 2026-02-17 16:36:37 [INFO] Updating MAC vendor database...
bluehood  | 2026-02-17 16:36:38 [INFO] Updating MAC vendor database...
bluehood  | 2026-02-17 16:36:43 [WARNING] Could not update vendor database: [Errno 2] No such file or directory: '/home/bluehood/.cache/mac-vendors.txt'
bluehood  | 2026-02-17 16:36:43 [WARNING] Could not update vendor database: [Errno 2] No such file or directory: '/home/bluehood/.cache/mac-vendors.txt'
```

They were caused by `os.path.expanduser()` method in the `mac_vendor_lookup` library, which created a directory in the user's $HOME. But during build time the directory wasn't created and vendor database wasn't updated upon build. So I've added one layer creating cache directory for this functionality. After changes the app updates database successfully:

```bash
bluehood  | 2026-02-17 16:56:09 [INFO] Updating MAC vendor database...
bluehood  | 2026-02-17 16:56:14 [INFO] Updating MAC vendor database...
...
bluehood  | 2026-02-17 16:56:28 [INFO] MAC vendor database updated
bluehood  | 2026-02-17 16:56:32 [INFO] MAC vendor database updated
```

Edit: I see that my PR is a different approach to the same problem as in #2. Feel free to close my PR in favor of the other.