### PR TITLE
feat: support dedicated adapter for classic Bluetooth scanning (dual-adapter mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ The web dashboard will be available at **http://localhost:8080**
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BLUEHOOD_ADAPTER` | auto | Bluetooth adapter (e.g., `hci0`) |
+| `BLUEHOOD_ADAPTER` | auto | Bluetooth adapter for BLE scanning (e.g., `hci0`) |
+| `BLUEHOOD_CLASSIC_ADAPTER` | same as `BLUEHOOD_ADAPTER` | Separate adapter for classic Bluetooth scanning (e.g., `hci1`). When set to a different adapter, BLE and classic scans run concurrently. |
 | `BLUEHOOD_DATA_DIR` | `/data` | Database storage directory |
 
 ### Bluetooth Adapter Requirements
@@ -231,6 +232,9 @@ bluehood --port 9000
 
 # Use a specific Bluetooth adapter
 bluehood --adapter hci1
+
+# Use separate adapters for BLE and classic scanning (concurrent)
+bluehood --adapter hci0 --classic-adapter hci1
 
 # List available adapters
 bluehood --list-adapters

--- a/bluehood/config.py
+++ b/bluehood/config.py
@@ -21,3 +21,8 @@ SCAN_DURATION = 5
 
 # Bluetooth adapter (None = auto-select, or specify like "hci0")
 BLUETOOTH_ADAPTER = os.environ.get("BLUEHOOD_ADAPTER", None)
+
+# Separate adapter for classic Bluetooth inquiry scans (None = use same as BLE).
+# Setting this to a different adapter (e.g. a USB dongle) allows BLE and classic
+# scans to run concurrently without adapter contention.
+CLASSIC_BLUETOOTH_ADAPTER = os.environ.get("BLUEHOOD_CLASSIC_ADAPTER", None)

--- a/bluehood/daemon.py
+++ b/bluehood/daemon.py
@@ -27,8 +27,8 @@ logger = logging.getLogger(__name__)
 class BluehoodDaemon:
     """Main daemon process for Bluetooth scanning."""
 
-    def __init__(self, adapter: Optional[str] = None, web_port: Optional[int] = None):
-        self.scanner = BluetoothScanner(adapter=adapter)
+    def __init__(self, adapter: Optional[str] = None, classic_adapter: Optional[str] = None, web_port: Optional[int] = None):
+        self.scanner = BluetoothScanner(adapter=adapter, classic_adapter=classic_adapter)
         self.running = False
         self.clients: list[asyncio.StreamWriter] = []
         self._server: asyncio.Server | None = None
@@ -39,6 +39,11 @@ class BluehoodDaemon:
     async def start(self) -> None:
         """Start the daemon."""
         logger.info("Starting bluehood daemon...")
+        if self.scanner._use_dual_adapter:
+            logger.info(f"Dual-adapter mode: BLE on {self.scanner.adapter}, classic on {self.scanner.classic_adapter}")
+        else:
+            adapter = self.scanner.adapter or "auto"
+            logger.info(f"Single-adapter mode: {adapter} (BLE and classic scans run sequentially)")
 
         # Initialize database
         await db.init_db()
@@ -358,7 +363,12 @@ def main() -> None:
     )
     parser.add_argument(
         "-a", "--adapter",
-        help="Bluetooth adapter to use (e.g., hci0)"
+        help="Bluetooth adapter for BLE scanning (e.g., hci0)"
+    )
+    parser.add_argument(
+        "--classic-adapter",
+        help="Separate adapter for classic Bluetooth scanning (e.g., hci1). "
+             "When set to a different adapter, BLE and classic scans run concurrently."
     )
     parser.add_argument(
         "-l", "--list-adapters",
@@ -389,7 +399,7 @@ def main() -> None:
         return
 
     web_port = None if args.no_web else args.port
-    daemon = BluehoodDaemon(adapter=args.adapter, web_port=web_port)
+    daemon = BluehoodDaemon(adapter=args.adapter, classic_adapter=args.classic_adapter, web_port=web_port)
     try:
         asyncio.run(daemon.start())
     except KeyboardInterrupt:

--- a/bluehood/scanner.py
+++ b/bluehood/scanner.py
@@ -22,7 +22,7 @@ except ImportError:
 MACVENDORS_API_URL = "https://api.macvendors.com/"
 
 from .classifier import is_macos_uuid
-from .config import SCAN_DURATION, BLUETOOTH_ADAPTER, DATA_DIR
+from .config import SCAN_DURATION, BLUETOOTH_ADAPTER, CLASSIC_BLUETOOTH_ADAPTER, DATA_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -141,10 +141,20 @@ def list_adapters() -> list[BluetoothAdapter]:
 
 
 class BluetoothScanner:
-    """Bluetooth LE scanner."""
+    """Bluetooth LE and classic scanner."""
 
-    def __init__(self, adapter: Optional[str] = None):
+    def __init__(
+        self,
+        adapter: Optional[str] = None,
+        classic_adapter: Optional[str] = None,
+    ):
         self.adapter = adapter or BLUETOOTH_ADAPTER
+        self.classic_adapter = classic_adapter or CLASSIC_BLUETOOTH_ADAPTER or self.adapter
+        self._use_dual_adapter = (
+            self.classic_adapter is not None
+            and self.adapter is not None
+            and self.classic_adapter != self.adapter
+        )
         self._mac_lookup: Optional[AsyncMacLookup] = None
         self._vendor_cache: dict[str, Optional[str]] = {}
         self._vendors_updated = False
@@ -273,7 +283,13 @@ class BluetoothScanner:
             if self.adapter:
                 kwargs["adapter"] = self.adapter
 
-            discovered = await BleakScanner.discover(**kwargs)
+            # Wrap in wait_for as a hard deadline — bleak's timeout parameter
+            # only controls the scan window duration, not the underlying D-Bus
+            # call which can block indefinitely if the adapter is busy.
+            discovered = await asyncio.wait_for(
+                BleakScanner.discover(**kwargs),
+                timeout=duration + 10,
+            )
 
             for device, adv_data in discovered.values():
                 mac = device.address
@@ -293,6 +309,8 @@ class BluetoothScanner:
 
             logger.debug(f"BLE scan: found {len(devices)} devices")
 
+        except asyncio.TimeoutError:
+            logger.warning("BLE scan timed out (adapter may be busy)")
         except Exception as e:
             logger.error(f"BLE scan error: {e}")
 
@@ -307,7 +325,7 @@ class BluetoothScanner:
 
         try:
             # Use hcitool for classic Bluetooth inquiry
-            adapter_arg = ["-i", self.adapter] if self.adapter else []
+            adapter_arg = ["-i", self.classic_adapter] if self.classic_adapter else []
 
             # Run inquiry scan
             proc = await asyncio.create_subprocess_exec(
@@ -385,22 +403,47 @@ class BluetoothScanner:
             return None
 
     async def scan(self, duration: float = SCAN_DURATION) -> list[ScannedDevice]:
-        """Perform both BLE and classic Bluetooth scans."""
-        # Run both scans concurrently
-        ble_task = asyncio.create_task(self.scan_ble(duration))
-        classic_task = asyncio.create_task(self.scan_classic())
+        """Perform both BLE and classic Bluetooth scans.
 
-        ble_devices, classic_devices = await asyncio.gather(
-            ble_task, classic_task, return_exceptions=True
-        )
+        When a dedicated classic adapter is configured, scans run concurrently
+        since they use separate hardware with no contention. Otherwise, scans
+        run sequentially (BLE first, then classic) to avoid locking the shared
+        adapter in INQUIRY mode which blocks BLE discovery via D-Bus.
 
-        # Handle any exceptions
-        if isinstance(ble_devices, Exception):
-            logger.error(f"BLE scan failed: {ble_devices}")
-            ble_devices = []
-        if isinstance(classic_devices, Exception):
-            logger.debug(f"Classic scan failed: {classic_devices}")
-            classic_devices = []
+        See: https://github.com/dannymcc/bluehood/issues/30
+        """
+        ble_devices: list[ScannedDevice] = []
+        classic_devices: list[ScannedDevice] = []
+
+        if self._use_dual_adapter:
+            # Separate adapters — safe to run concurrently
+            ble_task = asyncio.create_task(self.scan_ble(duration))
+            classic_task = asyncio.create_task(self.scan_classic())
+
+            results = await asyncio.gather(
+                ble_task, classic_task, return_exceptions=True
+            )
+
+            if isinstance(results[0], Exception):
+                logger.error(f"BLE scan failed: {results[0]}")
+            else:
+                ble_devices = results[0]
+
+            if isinstance(results[1], Exception):
+                logger.debug(f"Classic scan failed: {results[1]}")
+            else:
+                classic_devices = results[1]
+        else:
+            # Same adapter — run sequentially to avoid contention
+            try:
+                ble_devices = await self.scan_ble(duration)
+            except Exception as e:
+                logger.error(f"BLE scan failed: {e}")
+
+            try:
+                classic_devices = await self.scan_classic()
+            except Exception as e:
+                logger.debug(f"Classic scan failed: {e}")
 
         # Merge results, preferring BLE data if device seen in both
         seen_macs = set()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,11 @@ services:
       - bluehood-data:/data
 
     # Optional: specify Bluetooth adapter (default: auto-detect)
+    # Set BLUEHOOD_CLASSIC_ADAPTER to a different adapter (e.g. a USB dongle)
+    # to run BLE and classic scans concurrently without adapter contention.
     # environment:
     #   - BLUEHOOD_ADAPTER=hci0
+    #   - BLUEHOOD_CLASSIC_ADAPTER=hci1
 
     # Web dashboard available at http://localhost:8080
 


### PR DESCRIPTION
## Summary

- Add `BLUEHOOD_CLASSIC_ADAPTER` env var and `--classic-adapter` CLI flag to assign a separate Bluetooth adapter for classic inquiry scans
- When a dedicated classic adapter is configured (and differs from the BLE adapter), scans run **concurrently** via `asyncio.gather()` — safe since they use separate hardware
- When using a single adapter (default), scans run **sequentially** (BLE first, then classic) to avoid the INQUIRY deadlock from #30
- Add `asyncio.wait_for()` hard deadline around `BleakScanner.discover()` since bleak's `timeout` only controls the scan window, not the D-Bus call
- Log the adapter mode at startup for visibility ("Dual-adapter mode" vs "Single-adapter mode")

## Use Case

On SBCs like the Raspberry Pi 3B, the built-in BCM43438 can handle BLE scanning while a USB Bluetooth dongle handles classic inquiry — both concurrently with no adapter contention. This reduces scan cycle time from ~15s (sequential) back to ~10s (limited by the slower classic inquiry).

```yaml
environment:
  - BLUEHOOD_ADAPTER=hci0           # Built-in → BLE
  - BLUEHOOD_CLASSIC_ADAPTER=hci1   # USB dongle → classic
```

## Changes

| File | Change |
|------|--------|
| `bluehood/config.py` | New `CLASSIC_BLUETOOTH_ADAPTER` config from env var |
| `bluehood/scanner.py` | `BluetoothScanner` gains `classic_adapter` param; `scan()` picks concurrent or sequential based on adapter configuration; `scan_ble()` gets hard timeout; `scan_classic()` uses dedicated adapter |
| `bluehood/daemon.py` | `--classic-adapter` CLI flag; startup log showing adapter mode |
| `docker-compose.yml` | Document new `BLUEHOOD_CLASSIC_ADAPTER` env var |
| `README.md` | Add env var to table; add CLI usage example |

Closes #32
Also includes the fix for #30 (sequential scans on single adapter + BLE hard timeout)

## Test plan

- [x] Single adapter (default): verify scans run sequentially, no hang on RPi 3B
- [ ] Dual adapter (`--adapter hci0 --classic-adapter hci1`): verify scans run concurrently, both discover devices
- [ ] Same adapter explicitly set for both: verify sequential mode is used
- [x] Only `BLUEHOOD_CLASSIC_ADAPTER` set (no primary): verify graceful fallback
- [x] Startup log shows correct mode ("Dual-adapter mode" or "Single-adapter mode")
- [x] No regression on systems without classic Bluetooth support (hcitool missing)