### PR TITLE
fix: make MAC vendor DB update non-blocking with TTL cache and bundled fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ RUN pip install --no-cache-dir -e .
 # Create data directory for database and cache
 RUN mkdir -p /data && chown bluehood:bluehood /data
 
+# Bundle MAC vendor database at build time as fallback
+RUN python -c "from mac_vendor_lookup import MacLookup; MacLookup().update_vendors()" \
+    && cp /root/.cache/mac-vendors.txt /data/mac-vendors.txt \
+    && chown bluehood:bluehood /data/mac-vendors.txt \
+    || echo "Warning: could not bundle vendor DB"
+
 # Environment variables
 ENV BLUEHOOD_DATA_DIR=/data
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

Fixes #36

The MAC vendor database download (`MacLookup().update_vendors()`) was `await`ed directly in the scan path. If the IEEE server hangs (returns HTTP 418, times out, etc.), **all Bluetooth scanning stops indefinitely**.

This PR makes the vendor DB update fully non-blocking:

- **TTL cache**: skip the download entirely if the cached file (`mac-vendors.txt`) is less than 7 days old
- **Background task**: run the update as a fire-and-forget `asyncio.Task` instead of blocking `_get_vendor()`
- **Timeout**: wrap the download in `asyncio.wait_for(..., timeout=30)` so it can never hang
- **Bundled fallback**: download the vendor DB at Docker image build time so there's always a baseline, even on first run in restricted networks

## What changed

| File | Change |
|------|--------|
| `bluehood/scanner.py` | Replace blocking `_ensure_vendor_db()` with `_start_vendor_db_update()` (background), `_update_vendor_db()` (with timeout), and `_is_vendor_db_fresh()` (TTL check) |
| `Dockerfile` | Add build-time vendor DB download so `/data/mac-vendors.txt` is always present |

## Test plan

- [x] Start container with no cached vendor DB — should scan immediately while DB downloads in background
- [x] Start container with a fresh (<7d) cached vendor DB — should skip download entirely
- [x] Start container in a network where IEEE is blocked — should timeout after 30s and use bundled DB
- [x] Verify vendor names still resolve correctly for known MACs