### PR TITLE
macOS launchd install script, device-linkage analysis, DB cleanup, self-heal, and cleanup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Bluehood is a Bluetooth scanner that:
 - **Hourly and daily activity heatmaps** showing when devices are active
 - **Pattern analysis** ("Weekdays, evenings 5PM-9PM")
 - **Dwell time analysis** showing total time devices spend in range
-- **Device correlation** detection to find devices that appear together
+- **Device correlation** detection to find devices that appear together (co-presence plus synchronized arrival/departure)
+- **MAC-rotation linkage** ("Likely same device") — heuristically links randomized identifiers that hand off in time, share a similar signal strength, and ping at a similar cadence
 - **Proximity zones** (immediate, near, far, remote) based on signal strength
 - Search by MAC, vendor, or name
 - Date range search for historical queries
@@ -87,14 +88,14 @@ Bluehood is a Bluetooth scanner that:
 
 ### Operations
 - **Heartbeat check-in** — periodically POST status to an uptime monitoring service (e.g., Uptime Kuma, Healthchecks.io)
-- **Storage rotation** — automatically prune sightings older than a configurable number of days
+- **Storage rotation** — automatically prune sightings older than a configurable number of days; optionally restrict pruning to whole stale devices seen fewer than a minimum number of times (watched devices are never pruned)
 - Both configurable from the web UI or via environment variables
 
 ### Web Interface
 - **Compact/Detailed view toggle** for different display preferences
 - **Screenshot mode** to obfuscate MACs and names for safe sharing
 - **Keyboard shortcuts** for power users (press `?` to view)
-- **CSV export** of device data
+- **CSV export** of detailed device data (MAC, vendor, identifier, type, BT type, device class, watched/ignored flags, first/last seen, sightings, group, service UUIDs, and notes) — exports the whole filtered set, not just the current page
 - **Device groups** for organizing related devices
 - **Optional authentication** to secure access
 
@@ -160,6 +161,7 @@ The web dashboard will be available at **http://localhost:8080**
 | `BLUEHOOD_HEARTBEAT_URL` | disabled | URL to POST heartbeat check-ins (e.g., a healthchecks.io or uptime-kuma push URL) |
 | `BLUEHOOD_HEARTBEAT_INTERVAL` | `300` | Seconds between heartbeat check-ins |
 | `BLUEHOOD_PRUNE_DAYS` | `0` (disabled) | Auto-delete sightings older than N days to free storage |
+| `BLUEHOOD_PRUNE_MIN_SIGHTINGS` | `0` (disabled) | When >0, prune whole stale devices (older than `BLUEHOOD_PRUNE_DAYS` and with fewer than N total sightings) instead of only trimming old sighting rows; watched devices are never pruned |
 
 ### Bluetooth Adapter Requirements
 
@@ -275,6 +277,7 @@ The dashboard provides:
   - Pattern analysis
   - Dwell time statistics
   - Correlated devices list
+  - Likely same device (MAC rotation) list
   - Proximity zone indicator
   - Operator notes field
   - Group assignment

--- a/bluehood/config.py
+++ b/bluehood/config.py
@@ -36,3 +36,7 @@ HEARTBEAT_INTERVAL = int(os.environ.get("BLUEHOOD_HEARTBEAT_INTERVAL", "300"))  
 
 # Auto-prune sightings older than N days (0 = disabled)
 PRUNE_DAYS = int(os.environ.get("BLUEHOOD_PRUNE_DAYS", "0"))
+
+# When pruning, only remove stale devices with fewer than this many total
+# sightings (0 = disabled; prune by age only, keeping device records).
+PRUNE_MIN_SIGHTINGS = int(os.environ.get("BLUEHOOD_PRUNE_MIN_SIGHTINGS", "0"))

--- a/bluehood/daemon.py
+++ b/bluehood/daemon.py
@@ -7,6 +7,7 @@ import logging
 import os
 import platform
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -44,9 +45,65 @@ class BluehoodDaemon:
         self._http_session: aiohttp.ClientSession | None = None
         self._start_time = time.monotonic()
 
+    @staticmethod
+    async def _wait_for_bluetooth(max_wait: int = 120, interval: int = 5) -> None:
+        """Wait for the macOS Bluetooth controller to be powered on.
+
+        On macOS, launchd may start this daemon at login before
+        CoreBluetooth has finished initialising.  We poll the
+        ControllerPowerState pref (works on all modern macOS versions)
+        to avoid the "adapter busy" errors that bleak raises when it
+        tries to scan against a not-yet-ready adapter.
+
+        This is a no-op on non-macOS platforms.
+        """
+        if platform.system() != "Darwin":
+            return
+
+        waited = 0
+        logger.info("macOS detected – waiting for Bluetooth controller …")
+
+        while waited < max_wait:
+            try:
+                result = await asyncio.to_thread(
+                    subprocess.run,
+                    [
+                        "defaults", "read",
+                        "/Library/Preferences/com.apple.Bluetooth",
+                        "ControllerPowerState",
+                    ],
+                    capture_output=True, text=True, timeout=5,
+                )
+                power_state = result.stdout.strip()
+                if power_state == "1":
+                    logger.info(
+                        "Bluetooth controller is on (waited %ds).", waited
+                    )
+                    # Extra grace period for CoreBluetooth framework
+                    # initialisation after the controller reports ready.
+                    await asyncio.sleep(3)
+                    return
+                else:
+                    logger.debug(
+                        "Bluetooth power state: %s (not ready yet)", power_state
+                    )
+            except Exception as exc:
+                logger.debug("Bluetooth check failed: %s", exc)
+
+            await asyncio.sleep(interval)
+            waited += interval
+
+        logger.warning(
+            "Bluetooth not confirmed ready after %ds – proceeding anyway.", max_wait
+        )
+
     async def start(self) -> None:
         """Start the daemon."""
         logger.info("Starting bluehood daemon...")
+
+        # Block until the Bluetooth adapter is ready (macOS only).
+        await self._wait_for_bluetooth()
+
         if self.scanner._use_dual_adapter:
             logger.info(f"Dual-adapter mode: BLE on {self.scanner.adapter}, classic on {self.scanner.classic_adapter}")
         else:
@@ -314,10 +371,30 @@ class BluehoodDaemon:
             mac = request.get("mac")
             days = request.get("days", 30)
             window_minutes = request.get("window_minutes", 5)
+            gap_minutes = request.get("gap_minutes", 15)
+            edge_minutes = request.get("edge_minutes")
             if mac:
-                correlated = await db.get_correlated_devices(mac, days, window_minutes)
+                correlated = await db.get_correlated_devices(
+                    mac, days, window_minutes, gap_minutes, edge_minutes
+                )
                 return {"status": "ok", "correlated_devices": correlated}
             return {"status": "error", "message": "Missing mac"}
+
+        elif cmd == "get_rotation_candidates":
+            mac = request.get("mac")
+            days = request.get("days", 7)
+            if mac:
+                rotation = await db.get_rotation_candidates(mac, days)
+                return {"status": "ok", **rotation}
+            return {"status": "error", "message": "Missing mac"}
+
+        elif cmd == "get_name_groups":
+            include_ignored = request.get("include_ignored", False)
+            min_devices = request.get("min_devices", 2)
+            groups = await db.get_name_groups(
+                min_devices=min_devices, include_ignored=include_ignored
+            )
+            return {"status": "ok", "name_groups": groups}
 
         elif cmd == "get_proximity_stats":
             mac = request.get("mac")
@@ -430,10 +507,27 @@ class BluehoodDaemon:
             try:
                 settings = await db.get_settings()
                 prune_days = settings.prune_days
+                min_sightings = settings.prune_min_sightings
                 if prune_days > 0:
-                    deleted = await db.cleanup_old_sightings(prune_days)
-                    if deleted:
-                        logger.info(f"Pruned {deleted} sightings older than {prune_days} days")
+                    if min_sightings > 0:
+                        # Remove whole stale devices (and their sightings) that
+                        # were last seen >prune_days ago and seen <min_sightings times.
+                        deleted = await db.prune_stale_devices(prune_days, min_sightings)
+                        if deleted:
+                            logger.info(
+                                f"Pruned {deleted} stale devices "
+                                f"(older than {prune_days} days, fewer than {min_sightings} sightings)"
+                            )
+                    else:
+                        # Age-only: trim old sighting rows, keep device records.
+                        deleted = await db.cleanup_old_sightings(prune_days)
+                        if deleted:
+                            logger.info(f"Pruned {deleted} sightings older than {prune_days} days")
+                    # Pruning frees pages inside the database file but doesn't
+                    # shrink it; reclaim the disk space once enough has built up.
+                    reclaimed = await db.vacuum_if_fragmented()
+                    if reclaimed:
+                        logger.info(f"Vacuumed database, reclaimed ~{reclaimed} MB on disk")
                     await asyncio.sleep(3600)  # Once per hour
                 else:
                     await asyncio.sleep(300)  # Re-check for config changes

--- a/bluehood/db.py
+++ b/bluehood/db.py
@@ -1,12 +1,18 @@
 """Database operations for bluehood."""
 
+import bisect
 import json
+import logging
+import re
+import statistics
 import aiosqlite
 from datetime import datetime, timedelta
 from typing import Optional
 from dataclasses import dataclass
 
-from .config import DB_PATH, HEARTBEAT_URL, HEARTBEAT_INTERVAL, PRUNE_DAYS
+from .config import DB_PATH, HEARTBEAT_URL, HEARTBEAT_INTERVAL, PRUNE_DAYS, PRUNE_MIN_SIGHTINGS
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -67,6 +73,7 @@ class Settings:
     heartbeat_url: Optional[str] = None       # None = disabled
     heartbeat_interval: int = 300             # seconds
     prune_days: int = 0                       # 0 = disabled
+    prune_min_sightings: int = 0              # 0 = prune by age only (keep device records)
     # Authentication settings
     auth_enabled: bool = False
     auth_username: Optional[str] = None
@@ -123,10 +130,141 @@ _DEVICE_FILTER_TYPES = {
 }
 
 
+# The daemon runs the scan loop, the web server, and the prune loop in a single
+# event loop, but each call below opens its own connection (each in its own
+# thread). Those connections contend for SQLite's single write lock, and WAL can
+# silently fall back to rollback-journal mode on some Docker bind mounts (where
+# reads also block writes). Give every connection a generous busy timeout so it
+# waits for the lock instead of immediately raising "database is locked".
+_DB_TIMEOUT_SECONDS = 30.0
+
+
+def _connect() -> aiosqlite.Connection:
+    """Open a database connection sharing a common busy timeout."""
+    return aiosqlite.connect(DB_PATH, timeout=_DB_TIMEOUT_SECONDS)
+
+
+async def _enable_wal(db: aiosqlite.Connection) -> None:
+    """Enable WAL mode and warn loudly if SQLite silently falls back.
+
+    WAL is far more resilient to corruption on an unclean shutdown than the
+    default rollback journal. The PRAGMA can be accepted but silently fall back
+    to 'delete'/'truncate' mode on some filesystems (notably certain Docker
+    bind mounts) — which is exactly the condition that lets an interrupted write
+    leave an index out of sync with its table. Read the mode back and surface
+    the fallback so it is diagnosable rather than silent.
+    """
+    async with db.execute("PRAGMA journal_mode=WAL") as cursor:
+        row = await cursor.fetchone()
+    mode = (row[0] if row else "") or ""
+    if mode.lower() != "wal":
+        logger.warning(
+            "SQLite journal_mode is %r, not 'wal' (WAL fallback). The database "
+            "is more vulnerable to corruption on unclean shutdown; check the "
+            "filesystem backing %s.", mode, DB_PATH,
+        )
+
+
+_TREE_PAGE_RE = re.compile(r"\btree\s+(\d+)\s+page\b", re.IGNORECASE)
+
+
+async def _index_rootpages(db: aiosqlite.Connection) -> dict:
+    """Map each b-tree root page number to its object type ('table'/'index').
+
+    integrity_check reports page-level damage as "Tree N page M ..." where N is
+    the b-tree's root page. Resolving N back to its type lets us tell index
+    corruption (rebuildable) from table corruption (data loss) when the message
+    itself doesn't name an index.
+    """
+    async with db.execute(
+        "SELECT rootpage, type FROM sqlite_master WHERE rootpage IS NOT NULL"
+    ) as cursor:
+        return {row[0]: row[1] for row in await cursor.fetchall()}
+
+
+def _is_index_only(problems: list, roots: dict) -> bool:
+    """True only if every reported problem is confined to an index b-tree.
+
+    A line is index-related if it names an index, or points at a "Tree N" whose
+    root page belongs to an index. Anything ambiguous or table-related makes this
+    return False so we refuse to auto-repair and advise a restore instead.
+    """
+    for problem in problems:
+        for line in problem.splitlines():
+            line = line.strip()
+            if not line or line.startswith("***"):  # section header, not a fault
+                continue
+            if "index" in line.lower():
+                continue
+            match = _TREE_PAGE_RE.search(line)
+            if match and roots.get(int(match.group(1))) == "index":
+                continue
+            return False
+    return True
+
+
+async def _check_and_repair_integrity(db: aiosqlite.Connection) -> None:
+    """Verify integrity at startup and self-heal index-only corruption.
+
+    SQLite index corruption (e.g. "wrong # of entries in index ...") is fully
+    recoverable from the intact table data via REINDEX, with no data loss, so we
+    rebuild automatically. Corruption that touches table/page data is NOT safely
+    auto-repairable; we surface it loudly and leave the file untouched for manual
+    recovery from a backup.
+    """
+    try:
+        async with db.execute("PRAGMA integrity_check") as cursor:
+            rows = await cursor.fetchall()
+    except aiosqlite.DatabaseError as exc:
+        logger.error(
+            "Integrity check could not run (%s); the database may be severely "
+            "corrupt. Restore %s from a backup.", exc, DB_PATH,
+        )
+        return
+
+    problems = [r[0] for r in rows if r and r[0] != "ok"]
+    if not problems:
+        return
+
+    sample = "; ".join(problems[:5])
+    roots = await _index_rootpages(db)
+    if not _is_index_only(problems, roots):
+        logger.error(
+            "Database corruption detected that is NOT index-only (%d issue(s)): "
+            "%s. This is not safely auto-repairable; restore %s from a backup.",
+            len(problems), sample, DB_PATH,
+        )
+        return
+
+    logger.warning(
+        "Index corruption detected (%d issue(s)); rebuilding indexes via "
+        "REINDEX: %s", len(problems), sample,
+    )
+    try:
+        await db.execute("REINDEX")
+        await db.commit()
+        async with db.execute("PRAGMA integrity_check") as cursor:
+            rows = await cursor.fetchall()
+    except aiosqlite.DatabaseError as exc:
+        logger.error("REINDEX failed (%s); restore %s from a backup.", exc, DB_PATH)
+        return
+
+    remaining = [r[0] for r in rows if r and r[0] != "ok"]
+    if remaining:
+        logger.error(
+            "Index rebuild did not fully repair the database; %d issue(s) "
+            "remain: %s. Restore %s from a backup.",
+            len(remaining), "; ".join(remaining[:5]), DB_PATH,
+        )
+    else:
+        logger.info("Database integrity restored: REINDEX successful.")
+
+
 async def init_db() -> None:
     """Initialize the database schema."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("PRAGMA journal_mode=WAL")
+    async with _connect() as db:
+        await _enable_wal(db)
+        await _check_and_repair_integrity(db)
         await db.executescript(SCHEMA)
 
         # Migrations for devices table columns
@@ -184,7 +322,7 @@ def _parse_device_row(row) -> Device:
 
 async def get_device(mac: str) -> Optional[Device]:
     """Get a device by MAC address."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
             "SELECT * FROM devices WHERE mac = ?", (mac,)
@@ -197,7 +335,7 @@ async def get_device(mac: str) -> Optional[Device]:
 
 async def get_all_devices(include_ignored: bool = True) -> list[Device]:
     """Get all devices."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         query = "SELECT * FROM devices"
         if not include_ignored:
@@ -255,6 +393,17 @@ def _build_device_query_filters(
     return where_clause, params
 
 
+_DEVICE_SORT_MAP = {
+    "class": "COALESCE(d.device_type, 'unknown')",
+    "mac": "d.mac",
+    "vendor": "COALESCE(d.vendor, '')",
+    "identifier": "COALESCE(d.friendly_name, '')",
+    "sightings": "d.total_sightings",
+    "last_seen": "COALESCE(d.last_seen, '')",
+    "group": "COALESCE(g.name, '')",
+}
+
+
 async def get_devices_page(
     page: int = 1,
     page_size: int = 50,
@@ -270,16 +419,7 @@ async def get_devices_page(
     safe_page_size = max(1, min(page_size, 500))
     offset = (safe_page - 1) * safe_page_size
 
-    sort_map = {
-        "class": "COALESCE(d.device_type, 'unknown')",
-        "mac": "d.mac",
-        "vendor": "COALESCE(d.vendor, '')",
-        "identifier": "COALESCE(d.friendly_name, '')",
-        "sightings": "d.total_sightings",
-        "last_seen": "COALESCE(d.last_seen, '')",
-        "group": "COALESCE(g.name, '')",
-    }
-    sort_expr = sort_map.get(sort_column, sort_map["last_seen"])
+    sort_expr = _DEVICE_SORT_MAP.get(sort_column, _DEVICE_SORT_MAP["last_seen"])
     direction = "ASC" if str(sort_direction).lower() == "asc" else "DESC"
 
     where_clause, params = _build_device_query_filters(
@@ -292,7 +432,7 @@ async def get_devices_page(
     base_query = "FROM devices d LEFT JOIN device_groups g ON g.id = d.group_id"
     order_clause = f" ORDER BY {sort_expr} {direction}, d.mac ASC"
 
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
 
         async with db.execute(
@@ -309,6 +449,85 @@ async def get_devices_page(
         ) as cursor:
             rows = await cursor.fetchall()
             return ([_parse_device_row(row) for row in rows], total)
+
+
+async def get_devices_export(
+    include_ignored: bool = True,
+    device_filter: str = "all",
+    search: Optional[str] = None,
+    sort_column: str = "last_seen",
+    sort_direction: str = "desc",
+    exclude_randomized: bool = True,
+) -> list[Device]:
+    """Return every device matching the query (no pagination), for CSV export."""
+    sort_expr = _DEVICE_SORT_MAP.get(sort_column, _DEVICE_SORT_MAP["last_seen"])
+    direction = "ASC" if str(sort_direction).lower() == "asc" else "DESC"
+
+    where_clause, params = _build_device_query_filters(
+        include_ignored=include_ignored,
+        device_filter=device_filter,
+        search=search,
+        exclude_randomized=exclude_randomized,
+    )
+
+    base_query = "FROM devices d LEFT JOIN device_groups g ON g.id = d.group_id"
+    order_clause = f" ORDER BY {sort_expr} {direction}, d.mac ASC"
+
+    async with _connect() as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            f"SELECT d.* {base_query}{where_clause}{order_clause}",
+            params,
+        ) as cursor:
+            rows = await cursor.fetchall()
+            return [_parse_device_row(row) for row in rows]
+
+
+async def get_sightings_for_export(
+    macs: list[str],
+    days: Optional[int] = None,
+) -> list[dict]:
+    """Return every raw sighting (mac, timestamp, rssi) for the given devices.
+
+    This is the un-aggregated detail behind the device export: one record per
+    actual contact, not a summary. ``days`` limits to the last N days when set;
+    the default (None) exports the full history. Sightings are pulled in MAC
+    chunks to stay within SQLite's bound-parameter limit on large exports and
+    returned ordered by MAC then time.
+    """
+    if not macs:
+        return []
+
+    rows_out: list[dict] = []
+    chunk = 400  # well under SQLite's default bound-parameter limit
+
+    async with _connect() as db:
+        db.row_factory = aiosqlite.Row
+        for start in range(0, len(macs), chunk):
+            subset = macs[start:start + chunk]
+            placeholders = ", ".join("?" for _ in subset)
+            where = f"mac IN ({placeholders})"
+            params: list = list(subset)
+            if days is not None:
+                where += " AND timestamp > datetime('now', ?)"
+                params.append(f"-{days} days")
+
+            async with db.execute(
+                f"""
+                SELECT mac, timestamp, rssi FROM sightings
+                WHERE {where}
+                ORDER BY mac ASC, timestamp ASC
+                """,
+                params,
+            ) as cursor:
+                async for row in cursor:
+                    rows_out.append({
+                        "mac": row["mac"],
+                        "timestamp": row["timestamp"],
+                        "rssi": row["rssi"],
+                    })
+
+    return rows_out
 
 
 async def get_dashboard_stats(include_ignored: bool = True) -> dict:
@@ -337,7 +556,7 @@ async def get_dashboard_stats(include_ignored: bool = True) -> dict:
         {where_clause}
     """
 
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(query, (today_start.isoformat(), one_hour_ago.isoformat())) as cursor:
             row = await cursor.fetchone()
@@ -385,7 +604,7 @@ async def get_global_stats(include_ignored: bool = True) -> dict:
         {where_clause}
     """
 
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(query, (today_start,)) as cursor:
             row = await cursor.fetchone()
@@ -416,7 +635,7 @@ async def upsert_device(
     now = datetime.now()
     uuids_json = json.dumps(service_uuids) if service_uuids else None
 
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         # Check if device exists
         async with db.execute("SELECT * FROM devices WHERE mac = ?", (mac,)) as cursor:
@@ -496,7 +715,7 @@ async def upsert_device(
 
 async def set_friendly_name(mac: str, name: str) -> None:
     """Set a friendly name for a device."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "UPDATE devices SET friendly_name = ? WHERE mac = ?",
             (name, mac)
@@ -506,7 +725,7 @@ async def set_friendly_name(mac: str, name: str) -> None:
 
 async def set_ignored(mac: str, ignored: bool) -> None:
     """Set whether a device is ignored."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "UPDATE devices SET ignored = ? WHERE mac = ?",
             (1 if ignored else 0, mac)
@@ -516,7 +735,7 @@ async def set_ignored(mac: str, ignored: bool) -> None:
 
 async def set_watched(mac: str, watched: bool) -> None:
     """Set whether a device is a Device of Interest (watched)."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "UPDATE devices SET watched = ? WHERE mac = ?",
             (1 if watched else 0, mac)
@@ -526,7 +745,7 @@ async def set_watched(mac: str, watched: bool) -> None:
 
 async def set_device_type(mac: str, device_type: str) -> None:
     """Set the device type for a device."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "UPDATE devices SET device_type = ? WHERE mac = ?",
             (device_type, mac)
@@ -536,7 +755,7 @@ async def set_device_type(mac: str, device_type: str) -> None:
 
 async def set_device_notes(mac: str, notes: Optional[str]) -> None:
     """Set operator notes for a device."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "UPDATE devices SET notes = ? WHERE mac = ?",
             (notes if notes else None, mac)
@@ -546,7 +765,7 @@ async def set_device_notes(mac: str, notes: Optional[str]) -> None:
 
 async def mark_new_device_notified(mac: str) -> None:
     """Mark a device's new-device notification as sent."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "UPDATE devices SET new_device_notified = 1 WHERE mac = ?",
             (mac,)
@@ -556,7 +775,7 @@ async def mark_new_device_notified(mac: str) -> None:
 
 async def get_sightings(mac: str, days: int = 30) -> list[Sighting]:
     """Get sightings for a device within the last N days."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
             """
@@ -580,7 +799,7 @@ async def get_sightings(mac: str, days: int = 30) -> list[Sighting]:
 
 async def get_hourly_distribution(mac: str, days: int = 30) -> dict[int, int]:
     """Get hourly distribution of sightings for pattern analysis."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         async with db.execute(
             """
             SELECT strftime('%H', timestamp) as hour, COUNT(*) as count
@@ -597,7 +816,7 @@ async def get_hourly_distribution(mac: str, days: int = 30) -> dict[int, int]:
 
 async def get_daily_distribution(mac: str, days: int = 30) -> dict[int, int]:
     """Get daily distribution of sightings (0=Monday, 6=Sunday)."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         async with db.execute(
             """
             SELECT strftime('%w', timestamp) as day, COUNT(*) as count
@@ -615,7 +834,7 @@ async def get_daily_distribution(mac: str, days: int = 30) -> dict[int, int]:
 
 async def get_daily_sightings(mac: str, days: int = 30) -> list[dict]:
     """Get daily sighting counts for timeline visualization."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         async with db.execute(
             """
             SELECT date(timestamp) as date, COUNT(*) as count, AVG(rssi) as avg_rssi
@@ -639,13 +858,92 @@ async def get_daily_sightings(mac: str, days: int = 30) -> list[dict]:
 
 async def cleanup_old_sightings(days: int = 90) -> int:
     """Remove sightings older than N days. Returns count deleted."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         cursor = await db.execute(
             "DELETE FROM sightings WHERE timestamp < datetime('now', ?)",
             (f"-{days} days",)
         )
         await db.commit()
         return cursor.rowcount
+
+
+async def vacuum_if_fragmented(min_free_mb: float = 64.0) -> float:
+    """VACUUM the database when it has accumulated free pages worth reclaiming.
+
+    Deleting rows (e.g. pruning stale devices) frees pages inside the file but
+    does not shrink the file on disk — only VACUUM does, by rewriting it. VACUUM
+    is expensive and takes a brief exclusive lock, so we only run it once the
+    freelist is large enough to be worth the cost. After a VACUUM the freelist
+    drops back to ~0, so this self-throttles: it fires after a big prune and then
+    stays quiet until fragmentation builds up again.
+
+    Returns the approximate megabytes that were free before vacuuming (0.0 when
+    skipped).
+    """
+    async with _connect() as db:
+        async with db.execute("PRAGMA freelist_count") as cursor:
+            free_pages = (await cursor.fetchone())[0]
+        async with db.execute("PRAGMA page_size") as cursor:
+            page_size = (await cursor.fetchone())[0]
+
+        free_mb = free_pages * page_size / (1024 * 1024)
+        if free_mb < min_free_mb:
+            return 0.0
+
+        # VACUUM cannot run inside a transaction; make sure none is open.
+        await db.commit()
+        await db.execute("VACUUM")
+        return round(free_mb, 1)
+
+
+async def prune_stale_devices(days: int, min_sightings: int) -> int:
+    """Delete stale devices and all of their sightings.
+
+    A device is pruned only when it has not been seen for more than `days`
+    days AND has accumulated fewer than `min_sightings` total sightings.
+    Watched devices (Devices of Interest) are never pruned. The foreign key
+    on sightings is not enforced by SQLite, so the sighting rows are removed
+    explicitly. Returns the number of devices deleted.
+
+    Deletions are done in small MAC batches, each committed on its own. On a
+    large database a single bulk DELETE can hold the write lock for over a
+    minute, which both freezes the scanner and trips the busy timeout when the
+    scanner is actively writing — so the prune would throw and silently delete
+    nothing. Short, frequently-committed transactions let the scanner interleave.
+    """
+    if days <= 0 or min_sightings <= 0:
+        return 0
+
+    async with _connect() as db:
+        cutoff = f"-{days} days"
+        async with db.execute(
+            """
+            SELECT mac FROM devices
+            WHERE COALESCE(watched, 0) = 0
+              AND last_seen < datetime('now', ?)
+              AND total_sightings < ?
+            """,
+            (cutoff, min_sightings),
+        ) as cursor:
+            macs = [row[0] for row in await cursor.fetchall()]
+
+        if not macs:
+            return 0
+
+        deleted = 0
+        chunk = 400  # short transactions; also stays under SQLite's bound-param limit
+        for start in range(0, len(macs), chunk):
+            subset = macs[start:start + chunk]
+            placeholders = ", ".join("?" for _ in subset)
+            await db.execute(
+                f"DELETE FROM sightings WHERE mac IN ({placeholders})", subset
+            )
+            cursor = await db.execute(
+                f"DELETE FROM devices WHERE mac IN ({placeholders})", subset
+            )
+            await db.commit()
+            deleted += cursor.rowcount
+        return deleted
 
 
 async def search_devices(
@@ -657,7 +955,7 @@ async def search_devices(
     Search for devices by MAC and/or time range.
     Returns devices with sighting count in the specified range.
     """
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
 
         # Build query based on filters
@@ -738,7 +1036,7 @@ async def search_devices(
 
 async def get_settings() -> Settings:
     """Get all application settings."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute("SELECT key, value FROM settings") as cursor:
             rows = await cursor.fetchall()
@@ -756,6 +1054,7 @@ async def get_settings() -> Settings:
         heartbeat_url=settings_dict.get("heartbeat_url", HEARTBEAT_URL),
         heartbeat_interval=int(settings_dict.get("heartbeat_interval", str(HEARTBEAT_INTERVAL))),
         prune_days=int(settings_dict.get("prune_days", str(PRUNE_DAYS))),
+        prune_min_sightings=int(settings_dict.get("prune_min_sightings", str(PRUNE_MIN_SIGHTINGS))),
         auth_enabled=settings_dict.get("auth_enabled", "0") == "1",
         auth_username=settings_dict.get("auth_username"),
         auth_password_hash=settings_dict.get("auth_password_hash"),
@@ -764,7 +1063,7 @@ async def get_settings() -> Settings:
 
 async def set_setting(key: str, value: str) -> None:
     """Set a single setting value."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
             (key, value)
@@ -774,7 +1073,7 @@ async def set_setting(key: str, value: str) -> None:
 
 async def update_settings(settings: Settings) -> None:
     """Update all settings from a Settings object."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         settings_pairs = [
             ("ntfy_topic", settings.ntfy_topic or ""),
             ("ntfy_enabled", "1" if settings.ntfy_enabled else "0"),
@@ -787,6 +1086,7 @@ async def update_settings(settings: Settings) -> None:
             ("heartbeat_url", settings.heartbeat_url or ""),
             ("heartbeat_interval", str(settings.heartbeat_interval)),
             ("prune_days", str(settings.prune_days)),
+            ("prune_min_sightings", str(settings.prune_min_sightings)),
         ]
         for key, value in settings_pairs:
             await db.execute(
@@ -802,7 +1102,7 @@ async def update_auth_settings(
     password_hash: Optional[str] = None
 ) -> None:
     """Update authentication settings."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
             ("auth_enabled", "1" if enabled else "0")
@@ -826,7 +1126,7 @@ async def update_auth_settings(
 
 async def get_groups() -> list[DeviceGroup]:
     """Get all device groups."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute("SELECT * FROM device_groups ORDER BY name") as cursor:
             rows = await cursor.fetchall()
@@ -843,7 +1143,7 @@ async def get_groups() -> list[DeviceGroup]:
 
 async def get_group(group_id: int) -> Optional[DeviceGroup]:
     """Get a device group by ID."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
             "SELECT * FROM device_groups WHERE id = ?", (group_id,)
@@ -861,7 +1161,7 @@ async def get_group(group_id: int) -> Optional[DeviceGroup]:
 
 async def create_group(name: str, color: str = "#3b82f6", icon: str = "📁") -> DeviceGroup:
     """Create a new device group."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         cursor = await db.execute(
             "INSERT INTO device_groups (name, color, icon) VALUES (?, ?, ?)",
             (name, color, icon)
@@ -872,7 +1172,7 @@ async def create_group(name: str, color: str = "#3b82f6", icon: str = "📁") ->
 
 async def update_group(group_id: int, name: str, color: str, icon: str) -> None:
     """Update a device group."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "UPDATE device_groups SET name = ?, color = ?, icon = ? WHERE id = ?",
             (name, color, icon, group_id)
@@ -882,7 +1182,7 @@ async def update_group(group_id: int, name: str, color: str, icon: str) -> None:
 
 async def delete_group(group_id: int) -> None:
     """Delete a device group and unassign all devices."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         # Unassign devices from this group
         await db.execute(
             "UPDATE devices SET group_id = NULL WHERE group_id = ?",
@@ -895,7 +1195,7 @@ async def delete_group(group_id: int) -> None:
 
 async def set_device_group(mac: str, group_id: Optional[int]) -> None:
     """Assign a device to a group (or remove from group if None)."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         await db.execute(
             "UPDATE devices SET group_id = ? WHERE mac = ?",
             (group_id, mac)
@@ -905,7 +1205,7 @@ async def set_device_group(mac: str, group_id: Optional[int]) -> None:
 
 async def get_devices_by_group(group_id: int) -> list[Device]:
     """Get all devices in a group."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
             "SELECT * FROM devices WHERE group_id = ? ORDER BY last_seen DESC",
@@ -917,7 +1217,7 @@ async def get_devices_by_group(group_id: int) -> list[Device]:
 
 async def get_watched_devices() -> list[Device]:
     """Get all watched (devices of interest)."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
             "SELECT * FROM devices WHERE watched = 1 ORDER BY last_seen DESC"
@@ -928,7 +1228,7 @@ async def get_watched_devices() -> list[Device]:
 
 async def get_rssi_history(mac: str, days: int = 7) -> list[dict]:
     """Get RSSI history for a device for charting."""
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         async with db.execute(
             """
             SELECT timestamp, rssi
@@ -959,7 +1259,7 @@ async def get_dwell_time(mac: str, days: int = 30, gap_minutes: int = 15) -> dic
         dict with total_minutes, session_count, avg_session_minutes,
         longest_session_minutes, sessions list
     """
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         async with db.execute(
             """
             SELECT timestamp FROM sightings
@@ -1024,39 +1324,131 @@ async def get_dwell_time(mac: str, days: int = 30, gap_minutes: int = 15) -> dic
 # Device Correlation Analysis
 # ============================================================================
 
-async def get_correlated_devices(mac: str, days: int = 30, window_minutes: int = 5) -> list[dict]:
-    """Find devices frequently seen around the same time as the target device.
+def _sessions_from_timestamps(timestamps: list[datetime], gap_seconds: float) -> list[tuple[datetime, datetime]]:
+    """Collapse a sorted list of sighting timestamps into presence sessions.
 
-    This helps identify devices that may belong to the same person or group.
+    A gap larger than ``gap_seconds`` between consecutive sightings ends the
+    current session and starts a new one. Returns a list of (start, end)
+    tuples — start is an "arrival" (came online), end is a "departure"
+    (went offline).
+    """
+    if not timestamps:
+        return []
+
+    sessions: list[tuple[datetime, datetime]] = []
+    start = end = timestamps[0]
+    for ts in timestamps[1:]:
+        if (ts - end).total_seconds() > gap_seconds:
+            sessions.append((start, end))
+            start = ts
+        end = ts
+    sessions.append((start, end))
+    return sessions
+
+
+def _count_aligned_events(
+    target_events: list[datetime],
+    candidate_events: list[datetime],
+    window_seconds: float,
+) -> int:
+    """Count target events that have a candidate event within ``window_seconds``.
+
+    Both lists must be sorted ascending. Each target event contributes at most
+    one match, so the result is in ``[0, len(target_events)]``.
+    """
+    if not target_events or not candidate_events:
+        return 0
+
+    matched = 0
+    for event in target_events:
+        idx = bisect.bisect_left(candidate_events, event)
+        # Nearest candidate event is either at idx or idx-1.
+        nearest = None
+        if idx < len(candidate_events):
+            nearest = (candidate_events[idx] - event).total_seconds()
+        if idx > 0:
+            prev = (event - candidate_events[idx - 1]).total_seconds()
+            nearest = prev if nearest is None else min(nearest, prev)
+        if nearest is not None and nearest <= window_seconds:
+            matched += 1
+    return matched
+
+
+async def get_correlated_devices(
+    mac: str,
+    days: int = 30,
+    window_minutes: int = 5,
+    gap_minutes: int = 15,
+    edge_minutes: Optional[int] = None,
+) -> list[dict]:
+    """Find devices that share presence patterns with the target device.
+
+    Two complementary signals are combined, so this surfaces devices that may
+    belong to the same person or group:
+
+    * **Co-occurrence** — how often the two devices are seen at the same time
+      (within ``window_minutes``).
+    * **Transition sync** — how often they come online and go offline around
+      the same time. Sightings are collapsed into presence sessions (a gap
+      longer than ``gap_minutes`` starts a new session); a candidate's
+      session arrivals/departures are matched against the target's within
+      ``edge_minutes``. This distinguishes devices that genuinely arrive and
+      leave together from those that merely happen to be around a lot.
 
     Args:
         mac: Target device MAC address
         days: Number of days to analyze
         window_minutes: Time window for co-occurrence (default 5 minutes)
+        gap_minutes: Idle gap that ends a presence session (default 15 minutes)
+        edge_minutes: Tolerance for matching arrivals/departures
+            (defaults to ``window_minutes``)
 
     Returns:
-        List of correlated devices with correlation score
+        List of correlated devices, each with a combined ``correlation_score``
+        plus the ``cooccurrence_score`` and ``transition_score`` components and
+        the number of synced arrivals/departures.
     """
-    async with aiosqlite.connect(DB_PATH) as db:
+    if edge_minutes is None:
+        edge_minutes = window_minutes
+    edge_seconds = edge_minutes * 60
+    gap_seconds = gap_minutes * 60
+
+    async with _connect() as db:
         db.row_factory = aiosqlite.Row
 
-        # Get all sightings of the target device
+        # Get all sightings of the target device (ordered, for session building).
         async with db.execute(
             """
             SELECT timestamp FROM sightings
             WHERE mac = ? AND timestamp > datetime('now', ?)
+            ORDER BY timestamp ASC
             """,
             (mac, f"-{days} days")
         ) as cursor:
-            target_sightings = await cursor.fetchall()
+            target_rows = await cursor.fetchall()
 
-        if not target_sightings:
+        if not target_rows:
             return []
 
-        target_count = len(target_sightings)
+        target_count = len(target_rows)
+        target_ts = [datetime.fromisoformat(row[0]) for row in target_rows]
+        target_sessions = _sessions_from_timestamps(target_ts, gap_seconds)
+        target_arrivals = [s[0] for s in target_sessions]
+        target_departures = [s[1] for s in target_sessions]
+        target_edge_count = len(target_arrivals) + len(target_departures)
 
-        # For each target sighting, find other devices seen within the window
-        # Using a single query for efficiency
+        # Candidate pool: devices co-occurring with the target. We pull a wider
+        # pool than we return so transition sync can re-rank the results.
+        #
+        # Each window bound is computed from s1 with datetime() and rewritten to
+        # the 'T'-separated form that timestamps are stored in, so the bare,
+        # indexed s2.timestamp can be range-compared as a raw string. Wrapping
+        # the column itself in datetime() (the obvious way to normalize) forces a
+        # full scan of the sightings table per target sighting; seeking the index
+        # instead turns a ~30s query into single-digit milliseconds on a large
+        # database. datetime() truncates to whole seconds, so the upper bound is
+        # the next second (exclusive) to keep the boundary second inclusive,
+        # exactly matching the previous datetime()-on-both-sides comparison.
         async with db.execute(
             """
             SELECT
@@ -1068,7 +1460,8 @@ async def get_correlated_devices(mac: str, days: int = 30, window_minutes: int =
                 d.total_sightings
             FROM sightings s1
             JOIN sightings s2 ON s2.mac != s1.mac
-                AND s2.timestamp BETWEEN datetime(s1.timestamp, ?) AND datetime(s1.timestamp, ?)
+                AND s2.timestamp >= replace(datetime(s1.timestamp, ?), ' ', 'T')
+                AND s2.timestamp <  replace(datetime(s1.timestamp, ?, '+1 second'), ' ', 'T')
             JOIN devices d ON d.mac = s2.mac
             WHERE s1.mac = ?
                 AND s1.timestamp > datetime('now', ?)
@@ -1076,17 +1469,57 @@ async def get_correlated_devices(mac: str, days: int = 30, window_minutes: int =
             GROUP BY s2.mac
             HAVING co_occurrences >= 2
             ORDER BY co_occurrences DESC
-            LIMIT 20
+            LIMIT 50
             """,
             (f"-{window_minutes} minutes", f"+{window_minutes} minutes", mac, f"-{days} days")
         ) as cursor:
             rows = await cursor.fetchall()
 
+        if not rows:
+            return []
+
+        # Fetch every candidate's sightings in one pass and group by MAC so we
+        # can build their presence sessions in Python.
+        candidate_macs = [row["mac"] for row in rows]
+        placeholders = ", ".join("?" for _ in candidate_macs)
+        async with db.execute(
+            f"""
+            SELECT mac, timestamp FROM sightings
+            WHERE mac IN ({placeholders}) AND timestamp > datetime('now', ?)
+            ORDER BY mac ASC, timestamp ASC
+            """,
+            (*candidate_macs, f"-{days} days")
+        ) as cursor:
+            sighting_rows = await cursor.fetchall()
+
+        sightings_by_mac: dict[str, list[datetime]] = {}
+        for row in sighting_rows:
+            sightings_by_mac.setdefault(row["mac"], []).append(
+                datetime.fromisoformat(row["timestamp"])
+            )
+
         results = []
         for row in rows:
-            # Calculate correlation score (0-100)
-            # Based on ratio of co-occurrences to target sightings
-            correlation = min(100, round((row["co_occurrences"] / target_count) * 100))
+            # Co-occurrence: ratio of co-sightings to the target's sightings.
+            cooccurrence_score = min(100, round((row["co_occurrences"] / target_count) * 100))
+
+            # Transition sync: how many of the target's arrivals/departures the
+            # candidate matches with one of its own.
+            cand_sessions = _sessions_from_timestamps(
+                sightings_by_mac.get(row["mac"], []), gap_seconds
+            )
+            cand_arrivals = [s[0] for s in cand_sessions]
+            cand_departures = [s[1] for s in cand_sessions]
+            synced_arrivals = _count_aligned_events(target_arrivals, cand_arrivals, edge_seconds)
+            synced_departures = _count_aligned_events(target_departures, cand_departures, edge_seconds)
+            transition_score = (
+                round(((synced_arrivals + synced_departures) / target_edge_count) * 100)
+                if target_edge_count else 0
+            )
+
+            # Combined score weights co-presence and synchronized transitions
+            # equally so co-travellers outrank devices that are merely always around.
+            correlation = round(0.5 * cooccurrence_score + 0.5 * transition_score)
 
             results.append({
                 "mac": row["mac"],
@@ -1095,10 +1528,297 @@ async def get_correlated_devices(mac: str, days: int = 30, window_minutes: int =
                 "device_type": row["device_type"],
                 "co_occurrences": row["co_occurrences"],
                 "total_sightings": row["total_sightings"],
-                "correlation_score": correlation
+                "correlation_score": correlation,
+                "cooccurrence_score": cooccurrence_score,
+                "transition_score": transition_score,
+                "synced_arrivals": synced_arrivals,
+                "synced_departures": synced_departures,
             })
 
-        return results
+        results.sort(key=lambda r: (r["correlation_score"], r["co_occurrences"]), reverse=True)
+        return results[:20]
+
+
+def _median_ping_gap(timestamps: list[datetime]) -> Optional[float]:
+    """Median seconds between consecutive sightings (a device's ping cadence).
+
+    The median shrugs off the occasional long absence between presence
+    sessions, so it reflects the typical advertising interval.
+    """
+    if len(timestamps) < 2:
+        return None
+    gaps = [
+        (timestamps[i] - timestamps[i - 1]).total_seconds()
+        for i in range(1, len(timestamps))
+    ]
+    gaps = [g for g in gaps if g > 0]
+    return statistics.median(gaps) if gaps else None
+
+
+async def get_rotation_candidates(
+    mac: str,
+    days: int = 7,
+    rssi_tolerance: int = 6,
+    overlap_window_seconds: int = 30,
+    max_overlap_ratio: float = 0.1,
+    max_handoff_seconds: int = 1800,
+    min_sightings: int = 5,
+) -> dict:
+    """Find devices that are likely the *same physical device* as ``mac``.
+
+    Modern devices rotate their Bluetooth MAC for privacy, so one phone shows
+    up as many short-lived randomized identifiers. Two identifiers are flagged
+    as likely the same device when they:
+
+    * are both **randomized** (locally-administered) MACs,
+    * **coexist in the same overall period** but are essentially never seen at
+      the same instant — the old identity goes quiet as the new one appears
+      (a handoff rather than two co-present devices),
+    * sit at a **similar signal strength** (mean RSSI within ``rssi_tolerance``
+      dB), and
+    * **ping at a similar cadence**.
+
+    This is a probabilistic heuristic, not proof — RSSI is noisy and devices at
+    similar distances can coincide. Returns a dict with the target's own signal
+    profile and a confidence-ranked list of candidates.
+    """
+    empty = {"target": None, "candidates": []}
+
+    async with _connect() as db:
+        db.row_factory = aiosqlite.Row
+
+        # The advertised name is a strong same-device signal: some devices keep
+        # a constant local name (AirPods, named accessories) while rotating MAC.
+        async with db.execute(
+            "SELECT friendly_name FROM devices WHERE mac = ?", (mac,)
+        ) as cursor:
+            name_row = await cursor.fetchone()
+        target_name = ((name_row["friendly_name"] if name_row else "") or "").strip()
+
+        async with db.execute(
+            """
+            SELECT timestamp, rssi FROM sightings
+            WHERE mac = ? AND rssi IS NOT NULL AND timestamp > datetime('now', ?)
+            ORDER BY timestamp ASC
+            """,
+            (mac, f"-{days} days")
+        ) as cursor:
+            target_rows = await cursor.fetchall()
+
+        if len(target_rows) < min_sightings:
+            return empty
+
+        t_ts = [datetime.fromisoformat(r["timestamp"]) for r in target_rows]
+        t_rssi = [r["rssi"] for r in target_rows]
+        t_mean = statistics.fmean(t_rssi)
+        t_std = statistics.pstdev(t_rssi) if len(t_rssi) > 1 else 0.0
+        t_gap = _median_ping_gap(t_ts)
+        t_first, t_last = t_ts[0], t_ts[-1]
+
+        # Candidate pool: randomized, non-ignored devices at a comparable mean
+        # RSSI, with enough sightings to be meaningful. Filtered in SQL to keep
+        # the per-candidate Python work bounded. A device that shares the
+        # target's exact advertised name is admitted even when its RSSI falls
+        # outside the tolerance — the name is reason enough to evaluate it, and
+        # the handoff/non-overlap checks below still gate it on rotation shape.
+        randomized = _randomized_mac_sql("d.mac")
+        params = [mac, f"-{days} days", min_sightings, t_mean, rssi_tolerance]
+        name_having = ""
+        if target_name:
+            name_having = " OR lower(d.friendly_name) = lower(?)"
+            params.append(target_name)
+        async with db.execute(
+            f"""
+            SELECT s.mac AS mac, AVG(s.rssi) AS mean_rssi, COUNT(*) AS cnt
+            FROM sightings s
+            JOIN devices d ON d.mac = s.mac
+            WHERE s.mac != ?
+              AND s.rssi IS NOT NULL
+              AND s.timestamp > datetime('now', ?)
+              AND d.ignored = 0
+              AND {randomized}
+            GROUP BY s.mac
+            HAVING cnt >= ? AND (ABS(AVG(s.rssi) - ?) <= ?{name_having})
+            """,
+            params
+        ) as cursor:
+            cand_rows = await cursor.fetchall()
+
+        if not cand_rows:
+            return {"target": _rotation_target_profile(t_mean, t_std, t_gap, len(t_ts)), "candidates": []}
+
+        cand_macs = [r["mac"] for r in cand_rows]
+        placeholders = ", ".join("?" for _ in cand_macs)
+        async with db.execute(
+            f"""
+            SELECT mac, timestamp, rssi FROM sightings
+            WHERE mac IN ({placeholders}) AND rssi IS NOT NULL
+              AND timestamp > datetime('now', ?)
+            ORDER BY mac ASC, timestamp ASC
+            """,
+            (*cand_macs, f"-{days} days")
+        ) as cursor:
+            sighting_rows = await cursor.fetchall()
+
+        async with db.execute(
+            f"SELECT mac, vendor, friendly_name, device_type FROM devices WHERE mac IN ({placeholders})",
+            cand_macs
+        ) as cursor:
+            meta = {r["mac"]: r for r in await cursor.fetchall()}
+
+    by_mac: dict[str, list] = {}
+    for r in sighting_rows:
+        by_mac.setdefault(r["mac"], []).append(
+            (datetime.fromisoformat(r["timestamp"]), r["rssi"])
+        )
+
+    results = []
+    for cmac, pts in by_mac.items():
+        if len(pts) < min_sightings:
+            continue
+        c_ts = [p[0] for p in pts]
+        c_rssi = [p[1] for p in pts]
+        c_first, c_last = c_ts[0], c_ts[-1]
+
+        # Must belong to the same continuous presence: either the active windows
+        # overlap (interleaved rotation) or they sit back-to-back within a
+        # handoff gap (old identity goes quiet, new one appears shortly after).
+        if c_last < t_first:
+            handoff_gap = (t_first - c_last).total_seconds()
+        elif t_last < c_first:
+            handoff_gap = (c_first - t_last).total_seconds()
+        else:
+            handoff_gap = 0.0
+        if handoff_gap > max_handoff_seconds:
+            continue
+
+        # ...but must NOT ping simultaneously: the same physical device only
+        # broadcasts one random MAC at a time.
+        simultaneous = _count_aligned_events(c_ts, t_ts, overlap_window_seconds)
+        overlap_ratio = simultaneous / min(len(c_ts), len(t_ts))
+        if overlap_ratio > max_overlap_ratio:
+            continue
+
+        c_mean = statistics.fmean(c_rssi)
+        c_std = statistics.pstdev(c_rssi) if len(c_rssi) > 1 else 0.0
+        c_gap = _median_ping_gap(c_ts)
+
+        rssi_delta = abs(c_mean - t_mean)
+        rssi_sim = 1 - min(1.0, rssi_delta / rssi_tolerance)
+        cadence_sim = (min(t_gap, c_gap) / max(t_gap, c_gap)) if (t_gap and c_gap) else 0.0
+        separation = 1 - overlap_ratio
+        base = 0.4 * rssi_sim + 0.3 * separation + 0.3 * cadence_sim
+
+        m = meta[cmac]
+        cand_name = ((m["friendly_name"] or "")).strip()
+        name_match = bool(target_name) and cand_name.lower() == target_name.lower()
+        # A shared advertised name floors confidence at 60 and scales the signal
+        # heuristics into the top band; without it, the heuristics stand alone.
+        confidence = round(100 * (0.6 + 0.4 * base)) if name_match else round(100 * base)
+
+        results.append({
+            "mac": cmac,
+            "vendor": m["vendor"],
+            "friendly_name": m["friendly_name"],
+            "device_type": m["device_type"],
+            "name_match": name_match,
+            "confidence": confidence,
+            "mean_rssi": round(c_mean, 1),
+            "rssi_delta": round(rssi_delta, 1),
+            "rssi_stddev": round(c_std, 1),
+            "ping_interval_seconds": round(c_gap) if c_gap else None,
+            "overlap_ratio": round(overlap_ratio, 3),
+            "handoff_seconds": round(handoff_gap),
+            "sightings": len(c_ts),
+            "first_seen": c_first.isoformat() + "Z",
+            "last_seen": c_last.isoformat() + "Z",
+        })
+
+    results.sort(key=lambda x: x["confidence"], reverse=True)
+    return {
+        "target": _rotation_target_profile(t_mean, t_std, t_gap, len(t_ts)),
+        "candidates": results[:10],
+    }
+
+
+def _rotation_target_profile(mean: float, std: float, gap: Optional[float], count: int) -> dict:
+    """Signal profile for the device being inspected (shown for context)."""
+    return {
+        "mean_rssi": round(mean, 1),
+        "rssi_stddev": round(std, 1),
+        "ping_interval_seconds": round(gap) if gap else None,
+        "sightings": count,
+    }
+
+
+# ============================================================================
+# Name-based Grouping
+# ============================================================================
+
+async def get_name_groups(
+    min_devices: int = 2,
+    include_ignored: bool = False,
+) -> list[dict]:
+    """Group devices that advertise the same name across different MAC addresses.
+
+    Apple-style MAC randomization makes a single physical device surface as many
+    rows that share an identical advertised name. This collapses devices by their
+    exact (case-insensitive) ``friendly_name`` and returns only the names carried
+    by more than one MAC, so duplicates from rotation are visible at a glance.
+
+    Randomized MACs are intentionally included here — they are the whole point of
+    the view. Each group reports how many of its members are randomized so a
+    genuine rotating device (mostly randomized) reads differently from several
+    distinct devices that merely happen to share a generic name.
+    """
+    conditions = ["friendly_name IS NOT NULL", "TRIM(friendly_name) != ''"]
+    if not include_ignored:
+        conditions.append("ignored = 0")
+    where_clause = " AND ".join(conditions)
+    randomized_count_sql = _randomized_mac_sql("mac")
+    safe_min = max(2, min_devices)
+
+    async with _connect() as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            f"""
+            SELECT
+                MIN(friendly_name) AS name,
+                COUNT(*) AS device_count,
+                SUM(CASE WHEN {randomized_count_sql} THEN 1 ELSE 0 END) AS randomized_count,
+                SUM(COALESCE(total_sightings, 0)) AS total_sightings,
+                MIN(first_seen) AS first_seen,
+                MAX(last_seen) AS last_seen,
+                GROUP_CONCAT(mac, '||') AS macs,
+                GROUP_CONCAT(COALESCE(vendor, ''), '||') AS vendors,
+                GROUP_CONCAT(COALESCE(device_type, ''), '||') AS device_types
+            FROM devices
+            WHERE {where_clause}
+            GROUP BY lower(friendly_name)
+            HAVING device_count >= ?
+            ORDER BY device_count DESC, last_seen DESC
+            """,
+            (safe_min,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+
+    results = []
+    for row in rows:
+        macs = [m for m in (row["macs"] or "").split("||") if m]
+        vendors = [v for v in (row["vendors"] or "").split("||") if v]
+        types = [t for t in (row["device_types"] or "").split("||") if t]
+        results.append({
+            "name": row["name"],
+            "device_count": int(row["device_count"] or 0),
+            "randomized_count": int(row["randomized_count"] or 0),
+            "total_sightings": int(row["total_sightings"] or 0),
+            "first_seen": (row["first_seen"] + "Z") if row["first_seen"] else None,
+            "last_seen": (row["last_seen"] + "Z") if row["last_seen"] else None,
+            "macs": macs,
+            "vendor": vendors[0] if vendors else None,
+            "device_type": types[0] if types else None,
+        })
+    return results
 
 
 # ============================================================================
@@ -1131,7 +1851,7 @@ async def get_proximity_stats(mac: str, days: int = 7) -> dict:
 
     Returns distribution of sightings across proximity zones.
     """
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _connect() as db:
         async with db.execute(
             """
             SELECT rssi FROM sightings

--- a/bluehood/webapp/server.py
+++ b/bluehood/webapp/server.py
@@ -1,6 +1,9 @@
 """Web server for the Bluehood dashboard."""
 
+import csv
 import hashlib
+import io
+import json
 import logging
 import math
 import secrets
@@ -67,6 +70,8 @@ class WebServer:
         self.app.router.add_get("/settings", self.settings_page)
         self.app.router.add_get("/about", self.about_page)
         self.app.router.add_get("/api/devices", self.api_devices)
+        self.app.router.add_get("/api/devices/export", self.api_export_devices)
+        self.app.router.add_post("/api/devices/export", self.api_export_devices)
         self.app.router.add_get("/api/device/{mac}", self.api_device)
         self.app.router.add_post("/api/device/{mac}/watch", self.api_toggle_watch)
         self.app.router.add_post("/api/device/{mac}/group", self.api_set_device_group)
@@ -74,8 +79,10 @@ class WebServer:
         self.app.router.add_get("/api/device/{mac}/rssi", self.api_device_rssi)
         self.app.router.add_get("/api/device/{mac}/dwell", self.api_device_dwell)
         self.app.router.add_get("/api/device/{mac}/correlation", self.api_device_correlation)
+        self.app.router.add_get("/api/device/{mac}/rotation", self.api_device_rotation)
         self.app.router.add_get("/api/device/{mac}/proximity", self.api_device_proximity)
         self.app.router.add_post("/api/device/{mac}/notes", self.api_set_device_notes)
+        self.app.router.add_get("/api/name-groups", self.api_name_groups)
         self.app.router.add_get("/api/search", self.api_search)
         self.app.router.add_get("/api/stats", self.api_stats)
         # Settings
@@ -238,6 +245,230 @@ class WebServer:
             "has_next": page < total_pages,
         })
 
+    async def api_export_devices(self, request: web.Request) -> web.Response:
+        """Stream a CSV export (one row per sighting) for the matching devices.
+
+        The CSV is generated and streamed server-side so the browser downloads
+        straight to disk. Building it client-side meant pulling every sighting
+        into one giant JSON response (hundreds of MB on a busy sensor) and then
+        concatenating an even larger string in the page — which simply never
+        finished. Sightings are read in MAC batches so memory stays bounded
+        regardless of history size.
+
+        Accepts either GET query params or POST form fields. ``macs`` (a
+        comma-separated allow-list) pins the export to a specific selection or
+        date-filtered set; ``screenshot=1`` mirrors the dashboard's privacy
+        obfuscation. POST is used for large selections that would overflow a URL.
+        """
+        if request.method == "POST":
+            params = await request.post()
+        else:
+            params = request.query
+
+        device_filter = params.get("filter", "all")
+        search = params.get("search") or None
+        sort_column = params.get("sort", "last_seen")
+        sort_direction = params.get("direction", "desc")
+        screenshot = str(params.get("screenshot", "")).lower() in ("1", "true", "yes")
+        macs_param = params.get("macs")
+        explicit_macs = (
+            [m for m in macs_param.split(",") if m] if macs_param else None
+        )
+
+        # Export everything that matches the query, including randomized-MAC and
+        # ignored devices that the dashboard hides by default.
+        devices = await db.get_devices_export(
+            include_ignored=True,
+            device_filter=device_filter,
+            search=search,
+            sort_column=sort_column,
+            sort_direction=sort_direction,
+            exclude_randomized=False,
+        )
+
+        # A selection or date filter scopes the export to specific MACs, kept in
+        # the order the client supplied them.
+        if explicit_macs is not None:
+            order = {m: i for i, m in enumerate(explicit_macs)}
+            wanted = set(explicit_macs)
+            devices = [d for d in devices if d.mac in wanted]
+            devices.sort(key=lambda d: order.get(d.mac, len(order)))
+
+        groups = await db.get_groups()
+        group_lookup = {g.id: g for g in groups}
+
+        export_format = "json" if str(params.get("format", "csv")).lower() == "json" else "csv"
+
+        def _obfuscate_mac(mac: str) -> str:
+            if not screenshot or not mac:
+                return mac
+            if is_macos_uuid(mac):
+                return mac[:8] + "-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+            parts = mac.split(":")
+            if len(parts) == 6:
+                return parts[0] + ":" + parts[1] + ":XX:XX:XX:XX"
+            return mac[:5] + ":XX:XX:XX:XX"
+
+        def _obfuscate_name(name: str) -> str:
+            if not screenshot or not name:
+                return name
+            if len(name) <= 2:
+                return "**"
+            return name[:2] + "*" * min(len(name) - 2, 8)
+
+        filename = (
+            "bluehood-recon-" + datetime.now().strftime("%Y-%m-%d") + "." + export_format
+        )
+        content_type = (
+            "application/json; charset=utf-8"
+            if export_format == "json"
+            else "text/csv; charset=utf-8"
+        )
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": content_type,
+                "Content-Disposition": f'attachment; filename="{filename}"',
+            },
+        )
+        await response.prepare(request)
+
+        if export_format == "json":
+            await self._stream_devices_json(
+                response, devices, group_lookup, _obfuscate_mac, _obfuscate_name
+            )
+        else:
+            await self._stream_devices_csv(
+                response, devices, group_lookup, _obfuscate_mac, _obfuscate_name
+            )
+
+        await response.write_eof()
+        return response
+
+    async def _stream_devices_csv(
+        self, response, devices, group_lookup, obfuscate_mac, obfuscate_name
+    ) -> None:
+        """Write the device export as CSV (one row per sighting) to the stream."""
+        buffer = io.StringIO()
+        writer = csv.writer(buffer, lineterminator="\n")
+
+        def _flush() -> bytes:
+            data = buffer.getvalue().encode("utf-8")
+            buffer.seek(0)
+            buffer.truncate(0)
+            return data
+
+        writer.writerow([
+            "MAC", "Vendor", "Identifier", "Type", "BT_Type", "Device_Class",
+            "Watched", "Ignored", "First_Seen", "Last_Seen", "Total_Sightings",
+            "Group", "Service_UUIDs", "UUID_Names", "Notes",
+            "Sighting_Time", "RSSI", "Proximity_Zone",
+        ])
+        await response.write(_flush())
+
+        # Walk the devices in MAC batches, pulling each batch's raw sightings as
+        # we go so the full history never has to live in memory at once.
+        chunk = 400
+        for start in range(0, len(devices), chunk):
+            subset = devices[start:start + chunk]
+            sightings = await db.get_sightings_for_export([d.mac for d in subset])
+            sightings_by_mac: dict[str, list[dict]] = {}
+            for s in sightings:
+                sightings_by_mac.setdefault(s["mac"], []).append(s)
+
+            for d in subset:
+                device_type = d.device_type or classify_device(
+                    d.vendor, d.friendly_name, d.service_uuids, d.device_class,
+                )
+                group = group_lookup.get(d.group_id) if d.group_id else None
+                uuids = "; ".join(d.service_uuids) if d.service_uuids else ""
+                uuid_names = "; ".join(get_uuid_names(d.service_uuids) or [])
+                base = [
+                    obfuscate_mac(d.mac),
+                    d.vendor or "",
+                    obfuscate_name(d.friendly_name) if d.friendly_name else "",
+                    get_type_label(device_type) or device_type or "",
+                    d.bt_type or "",
+                    d.device_class if d.device_class is not None else "",
+                    "Yes" if d.watched else "No",
+                    "Yes" if d.ignored else "No",
+                    (d.first_seen.isoformat() + "Z") if d.first_seen else "",
+                    (d.last_seen.isoformat() + "Z") if d.last_seen else "",
+                    d.total_sightings if d.total_sightings is not None else "",
+                    group.name if group else "",
+                    uuids,
+                    uuid_names,
+                    d.notes or "",
+                ]
+                device_sightings = sightings_by_mac.get(d.mac)
+                if not device_sightings:
+                    # Keep the device even if it has no stored sightings.
+                    writer.writerow(base + ["", "", ""])
+                    continue
+                for s in device_sightings:
+                    rssi = s.get("rssi")
+                    writer.writerow(base + [
+                        s.get("timestamp") or "",
+                        rssi if rssi is not None else "",
+                        db.rssi_to_proximity_zone(rssi),
+                    ])
+            await response.write(_flush())
+
+    async def _stream_devices_json(
+        self, response, devices, group_lookup, obfuscate_mac, obfuscate_name
+    ) -> None:
+        """Write the device export as a JSON array (sightings nested per device).
+
+        Streamed device-by-device behind a single top-level array so the whole
+        history never has to be assembled in memory, mirroring the CSV path.
+        """
+        await response.write(b"[")
+        first = True
+        chunk = 400
+        for start in range(0, len(devices), chunk):
+            subset = devices[start:start + chunk]
+            sightings = await db.get_sightings_for_export([d.mac for d in subset])
+            sightings_by_mac: dict[str, list[dict]] = {}
+            for s in sightings:
+                sightings_by_mac.setdefault(s["mac"], []).append(s)
+
+            for d in subset:
+                device_type = d.device_type or classify_device(
+                    d.vendor, d.friendly_name, d.service_uuids, d.device_class,
+                )
+                group = group_lookup.get(d.group_id) if d.group_id else None
+                record = {
+                    "mac": obfuscate_mac(d.mac),
+                    "vendor": d.vendor,
+                    "identifier": obfuscate_name(d.friendly_name) if d.friendly_name else None,
+                    "type": get_type_label(device_type) or device_type,
+                    "device_type": device_type,
+                    "bt_type": d.bt_type,
+                    "device_class": d.device_class,
+                    "watched": bool(d.watched),
+                    "ignored": bool(d.ignored),
+                    "first_seen": (d.first_seen.isoformat() + "Z") if d.first_seen else None,
+                    "last_seen": (d.last_seen.isoformat() + "Z") if d.last_seen else None,
+                    "total_sightings": d.total_sightings,
+                    "group": group.name if group else None,
+                    "service_uuids": d.service_uuids or [],
+                    "uuid_names": get_uuid_names(d.service_uuids) or [],
+                    "notes": d.notes or None,
+                    "sightings": [
+                        {
+                            "timestamp": s.get("timestamp"),
+                            "rssi": s.get("rssi"),
+                            "proximity_zone": db.rssi_to_proximity_zone(s.get("rssi")),
+                        }
+                        for s in sightings_by_mac.get(d.mac, [])
+                    ],
+                }
+                prefix = b"" if first else b","
+                first = False
+                await response.write(prefix + json.dumps(record).encode("utf-8"))
+
+        await response.write(b"]")
+
     async def api_device(self, request: web.Request) -> web.Response:
         """Get detailed info for a single device."""
         mac = request.match_info["mac"]
@@ -365,9 +596,23 @@ class WebServer:
         mac = request.match_info["mac"]
         days = int(request.query.get("days", "30"))
         window_minutes = int(request.query.get("window", "5"))
+        gap_minutes = int(request.query.get("gap", "15"))
+        edge_raw = request.query.get("edge")
+        edge_minutes = int(edge_raw) if edge_raw not in (None, "") else None
 
-        correlated = await db.get_correlated_devices(mac, days, window_minutes)
+        correlated = await db.get_correlated_devices(
+            mac, days, window_minutes, gap_minutes, edge_minutes
+        )
         return web.json_response({"mac": mac, "correlated_devices": correlated})
+
+    async def api_device_rotation(self, request: web.Request) -> web.Response:
+        """Find devices likely to be the same physical device (MAC rotation)."""
+        mac = request.match_info["mac"]
+        days = int(request.query.get("days", "7"))
+        tolerance = int(request.query.get("tolerance", "6"))
+
+        rotation = await db.get_rotation_candidates(mac, days, rssi_tolerance=tolerance)
+        return web.json_response({"mac": mac, **rotation})
 
     async def api_device_proximity(self, request: web.Request) -> web.Response:
         """Get proximity zone statistics for a device."""
@@ -443,6 +688,17 @@ class WebServer:
 
         return ", ".join(parts) if parts else "No clear pattern"
 
+    async def api_name_groups(self, request: web.Request) -> web.Response:
+        """List names shared by more than one MAC (MAC-randomization duplicates)."""
+        include_ignored = str(request.query.get("include_ignored", "")).lower() in ("1", "true", "yes")
+        groups = await db.get_name_groups(min_devices=2, include_ignored=include_ignored)
+        for g in groups:
+            device_type = g.get("device_type") or classify_device(g.get("vendor"), g.get("name"))
+            g["device_type"] = device_type
+            g["type_icon"] = get_type_icon(device_type)
+            g["type_label"] = get_type_label(device_type)
+        return web.json_response({"groups": groups, "total": len(groups)})
+
     async def api_search(self, request: web.Request) -> web.Response:
         """Search for devices seen within a datetime range."""
         start_str = request.query.get("start")
@@ -516,6 +772,7 @@ class WebServer:
             "heartbeat_url": settings.heartbeat_url or "",
             "heartbeat_interval": settings.heartbeat_interval,
             "prune_days": settings.prune_days,
+            "prune_min_sightings": settings.prune_min_sightings,
         })
 
     async def api_update_settings(self, request: web.Request) -> web.Response:
@@ -535,6 +792,7 @@ class WebServer:
                 heartbeat_url=heartbeat_url,
                 heartbeat_interval=int(data.get("heartbeat_interval", 300)),
                 prune_days=int(data.get("prune_days", 0)),
+                prune_min_sightings=int(data.get("prune_min_sightings", 0)),
             )
             await db.update_settings(settings)
 

--- a/bluehood/webapp/templates.py
+++ b/bluehood/webapp/templates.py
@@ -926,16 +926,23 @@ HTML_TEMPLATE = """
                 <button class="filter-btn" id="click-to-open-toggle" onclick="toggleClickToOpen()" style="width: 100%; justify-content: center; margin-top: 0.5rem;">
                     👆 Click to Open
                 </button>
+                <button class="filter-btn" id="name-groups-toggle" onclick="toggleNameGroups()" style="width: 100%; justify-content: center; margin-top: 0.5rem;">
+                    🔗 Group by Name
+                </button>
             </div>
         </aside>
 
         <main class="content">
             <div class="search-bar">
                 <input type="text" class="search-input" id="search" placeholder="Search MAC, vendor, or identifier...">
-                <button class="btn" id="export-btn" onclick="exportData()">Export CSV</button>
+                <select class="form-input bulk-select" id="export-format" aria-label="Export format" style="min-width: 5rem;">
+                    <option value="csv" selected>CSV</option>
+                    <option value="json">JSON</option>
+                </select>
+                <button class="btn" id="export-btn" onclick="exportData()">Export</button>
             </div>
 
-            <div class="table-container">
+            <div class="table-container" id="devices-container">
                 <div class="table-header">
                     <span class="table-title">Identified Targets <span id="selected-count" class="selected-summary" style="display: none;">· 0 selected</span></span>
                     <div class="table-actions">
@@ -992,6 +999,18 @@ HTML_TEMPLATE = """
                             <option value="250">250</option>
                         </select>
                     </div>
+                </div>
+            </div>
+
+            <div class="table-container" id="name-groups-container" style="display: none;">
+                <div class="table-header">
+                    <span class="table-title">Devices Sharing a Name <span id="name-groups-count" class="selected-summary" style="display: none;"></span></span>
+                    <span style="font-size: 0.7rem; color: var(--text-muted);">
+                        Identical advertised name across multiple MACs — likely MAC randomization.
+                    </span>
+                </div>
+                <div id="name-groups-list" style="padding: 0.5rem 1rem 1rem;">
+                    <div style="text-align: center; padding: 2rem; color: var(--text-muted);">Loading...</div>
                 </div>
             </div>
         </main>
@@ -1159,6 +1178,67 @@ HTML_TEMPLATE = """
                 btn.style.background = clickToOpen ? 'var(--accent-blue)' : '';
                 btn.style.color = clickToOpen ? 'white' : '';
             }
+        }
+
+        let nameGroupsActive = false;
+
+        function toggleNameGroups() {
+            nameGroupsActive = !nameGroupsActive;
+            const devicesEl = document.getElementById('devices-container');
+            const groupsEl = document.getElementById('name-groups-container');
+            if (devicesEl) devicesEl.style.display = nameGroupsActive ? 'none' : '';
+            if (groupsEl) groupsEl.style.display = nameGroupsActive ? '' : 'none';
+            const btn = document.getElementById('name-groups-toggle');
+            if (btn) {
+                btn.innerHTML = nameGroupsActive ? '🔗 Group by Name ON' : '🔗 Group by Name';
+                btn.style.background = nameGroupsActive ? 'var(--accent-blue)' : '';
+                btn.style.color = nameGroupsActive ? 'white' : '';
+            }
+            if (nameGroupsActive) loadNameGroups();
+        }
+
+        async function loadNameGroups() {
+            const container = document.getElementById('name-groups-list');
+            const countEl = document.getElementById('name-groups-count');
+            if (!container) return;
+            container.innerHTML = '<div style="text-align: center; padding: 2rem; color: var(--text-muted);">Loading...</div>';
+            try {
+                const response = await fetch('/api/name-groups');
+                const data = await response.json();
+                const groups = data.groups || [];
+                if (countEl) {
+                    countEl.style.display = '';
+                    countEl.textContent = '· ' + groups.length + ' name' + (groups.length === 1 ? '' : 's');
+                }
+                if (groups.length === 0) {
+                    container.innerHTML = '<div style="text-align: center; padding: 2rem; color: var(--text-muted);">No names are shared across multiple addresses.</div>';
+                    return;
+                }
+                container.innerHTML = groups.map(renderNameGroup).join('');
+            } catch (error) {
+                container.innerHTML = '<div style="text-align: center; padding: 2rem; color: var(--text-muted);">Error loading name groups</div>';
+            }
+        }
+
+        function renderNameGroup(g) {
+            const name = obfuscateName(g.name) || '(unnamed)';
+            const { text: lastSeen, tooltip: lastSeenTooltip } = formatLastSeen(g.last_seen);
+            const vendor = g.vendor ? ' · ' + g.vendor : '';
+            const randomized = g.randomized_count > 0
+                ? '<span title="' + g.randomized_count + ' of ' + g.device_count + ' addresses are randomized" style="font-size: 0.65rem; color: var(--accent-amber); border: 1px solid var(--accent-amber); border-radius: 3px; padding: 0 0.3rem; margin-left: 0.5rem;">' + g.randomized_count + ' randomized</span>'
+                : '';
+            const members = (g.macs || []).map(mac => {
+                const shownMac = isMacOSUUID(mac) ? obfuscateMAC(mac).substring(0, 13) + '...' : obfuscateMAC(mac);
+                return '<div onclick="showDevice(\\'' + mac + '\\')" title="' + mac + '" style="font-family: monospace; font-size: 0.72rem; color: var(--text-secondary); padding: 0.25rem 0.5rem; border-bottom: 1px solid var(--border-color); cursor: pointer;">' + shownMac + '</div>';
+            }).join('');
+            return '<div style="margin-bottom: 1rem; border: 1px solid var(--border-color); border-radius: 6px; overflow: hidden;">' +
+                '<div style="display: flex; justify-content: space-between; align-items: center; padding: 0.6rem 0.75rem; background: var(--bg-tertiary);">' +
+                '<div style="min-width: 0;">' +
+                '<span style="font-size: 0.85rem; color: var(--text-primary); font-weight: 600;">' + (g.type_icon || '') + ' ' + name + '</span>' + randomized +
+                '<div style="font-size: 0.65rem; color: var(--text-muted);">' + g.device_count + ' addresses' + vendor + ' · ' + g.total_sightings + ' sightings · last seen <span title="' + lastSeenTooltip + '">' + lastSeen + '</span></div>' +
+                '</div>' +
+                '<span style="font-size: 1.1rem; font-weight: 700; color: var(--accent-blue); margin-left: 0.75rem;">' + g.device_count + '</span>' +
+                '</div>' + members + '</div>';
         }
 
         function isMacOSUUID(addr) {
@@ -1779,13 +1859,24 @@ HTML_TEMPLATE = """
                 '<div class="rssi-chart" id="rssi-chart"><div style="color: var(--text-muted); font-size: 0.75rem; text-align: center; padding-top: 1.5rem;">Loading...</div></div>' +
                 '</div>' +
                 '<div class="heatmap-section">' +
-                '<div class="heatmap-title">Correlated Devices</div>' +
+                '<div class="heatmap-title" style="display: flex; justify-content: space-between; align-items: center; gap: 0.5rem;">' +
+                '<span>Correlated Devices</span>' +
+                '<span style="font-weight: normal; font-size: 0.65rem; color: var(--text-muted); display: flex; align-items: center; gap: 0.3rem;">' +
+                'gap <input id="corr-gap" type="number" min="1" max="240" value="15" title="Idle minutes that end a presence session" onchange="reloadCorrelated()" style="width: 44px; background: var(--bg-secondary); color: var(--text-primary); border: 1px solid var(--border-color); border-radius: 3px; padding: 1px 3px; font-size: 0.65rem;">m' +
+                ' · sync ±<input id="corr-edge" type="number" min="1" max="120" value="5" title="Tolerance (minutes) for matching arrivals and departures" onchange="reloadCorrelated()" style="width: 44px; background: var(--bg-secondary); color: var(--text-primary); border: 1px solid var(--border-color); border-radius: 3px; padding: 1px 3px; font-size: 0.65rem;">m' +
+                '</span>' +
+                '</div>' +
                 '<div id="correlated-devices" class="heatmap"><div style="color: var(--text-muted);">Loading...</div></div>' +
+                '</div>' +
+                '<div class="heatmap-section">' +
+                '<div class="heatmap-title">Likely Same Device (MAC rotation)</div>' +
+                '<div id="rotation-candidates" class="heatmap"><div style="color: var(--text-muted);">Loading...</div></div>' +
                 '</div>';
 
             loadRssiChart(d.mac);
             loadDwellStats(d.mac);
             loadCorrelatedDevices(d.mac);
+            loadRotationCandidates(d.mac);
             loadGroupsForDevice(d.group_id);
         }
 
@@ -1905,11 +1996,22 @@ HTML_TEMPLATE = """
             }
         }
 
+        let correlationMac = null;
+
+        function reloadCorrelated() {
+            if (correlationMac) loadCorrelatedDevices(correlationMac);
+        }
+
         async function loadCorrelatedDevices(mac) {
+            correlationMac = mac;
             const container = document.getElementById('correlated-devices');
             if (!container) return;
+            const gapEl = document.getElementById('corr-gap');
+            const edgeEl = document.getElementById('corr-edge');
+            const gap = Math.max(1, parseInt(gapEl && gapEl.value) || 15);
+            const edge = Math.max(1, parseInt(edgeEl && edgeEl.value) || 5);
             try {
-                const response = await fetch('/api/device/' + encodeURIComponent(mac) + '/correlation?days=30');
+                const response = await fetch('/api/device/' + encodeURIComponent(mac) + '/correlation?days=30&gap=' + gap + '&edge=' + edge);
                 const data = await response.json();
                 if (!data.correlated_devices || data.correlated_devices.length === 0) {
                     container.innerHTML = '<div style="color: var(--text-muted); font-size: 0.75rem;">No correlated devices found</div>';
@@ -1921,16 +2023,69 @@ HTML_TEMPLATE = """
                     const rawSecondaryInfo = c.friendly_name ? (c.vendor || c.mac) : c.mac;
                     const secondaryInfo = (c.friendly_name && c.vendor) ? rawSecondaryInfo : obfuscateMAC(rawSecondaryInfo);
                     const corrBar = '<div style="background: var(--accent-red); height: 4px; width: ' + c.correlation_score + '%; border-radius: 2px;"></div>';
-                    return '<div style="display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid var(--border-color); cursor: pointer;" onclick="openDeviceModal(\\'' + c.mac + '\\')">' +
+                    const syncedEdges = (c.synced_arrivals || 0) + (c.synced_departures || 0);
+                    const syncLine = syncedEdges > 0
+                        ? '<div style="font-size: 0.65rem; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">⇄ ' + (c.synced_arrivals || 0) + ' arrivals / ' + (c.synced_departures || 0) + ' departures in sync</div>'
+                        : '';
+                    const corrTitle = 'Correlation ' + c.correlation_score + '% (co-presence ' + (c.cooccurrence_score != null ? c.cooccurrence_score : 0) + '%, transition sync ' + (c.transition_score != null ? c.transition_score : 0) + '%)';
+                    return '<div title="' + corrTitle + '" style="display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid var(--border-color); cursor: pointer;" onclick="showDevice(\\'' + c.mac + '\\')">' +
                         '<div style="flex: 1; min-width: 0;">' +
                         '<div style="font-size: 0.8rem; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">' + primaryName + '</div>' +
                         '<div style="font-size: 0.65rem; color: var(--text-muted); font-family: var(--font-mono); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">' + secondaryInfo + '</div>' +
+                        syncLine +
                         '</div>' +
                         '<div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 0.5rem;">' +
                         '<div style="width: 50px;">' + corrBar + '</div>' +
                         '<span style="font-size: 0.7rem; color: var(--accent-amber); min-width: 32px; text-align: right;">' + c.correlation_score + '%</span>' +
                         '</div></div>';
                 }).join('');
+            } catch (error) {
+                container.innerHTML = '<div style="color: var(--text-muted);">Error loading data</div>';
+            }
+        }
+
+        function formatPing(seconds) {
+            if (seconds == null) return 'n/a';
+            if (seconds >= 90) return '~' + Math.round(seconds / 60) + 'm';
+            return '~' + Math.round(seconds) + 's';
+        }
+
+        async function loadRotationCandidates(mac) {
+            const container = document.getElementById('rotation-candidates');
+            if (!container) return;
+            try {
+                const response = await fetch('/api/device/' + encodeURIComponent(mac) + '/rotation?days=7');
+                const data = await response.json();
+                const candidates = data.candidates || [];
+                const t = data.target;
+                let html = '';
+                if (t) {
+                    html += '<div style="font-size: 0.65rem; color: var(--text-muted); margin-bottom: 0.4rem;">This device: RSSI ' + t.mean_rssi + '±' + t.rssi_stddev + ' dBm · ping ' + formatPing(t.ping_interval_seconds) + '</div>';
+                }
+                if (candidates.length === 0) {
+                    html += '<div style="color: var(--text-muted); font-size: 0.75rem;">No likely rotation siblings found</div>';
+                    container.innerHTML = html;
+                    return;
+                }
+                html += candidates.map(c => {
+                    const rawPrimary = c.friendly_name || c.vendor || c.mac;
+                    const primaryName = c.friendly_name ? obfuscateName(rawPrimary) : (c.vendor ? rawPrimary : obfuscateMAC(c.mac));
+                    const overlapPct = Math.round((c.overlap_ratio || 0) * 100);
+                    const detail = 'RSSI ' + c.mean_rssi + '±' + c.rssi_stddev + ' (Δ' + c.rssi_delta + ') · ping ' + formatPing(c.ping_interval_seconds) + ' · ' + overlapPct + '% overlap';
+                    const nameBadge = c.name_match ? ' <span style="font-size: 0.6rem; color: var(--accent-amber); border: 1px solid var(--accent-amber); border-radius: 3px; padding: 0 0.25rem; vertical-align: middle;">name match</span>' : '';
+                    const bar = '<div style="background: var(--accent-amber); height: 4px; width: ' + c.confidence + '%; border-radius: 2px;"></div>';
+                    const title = 'Confidence ' + c.confidence + '% — ' + (c.name_match ? 'shares this device\\'s advertised name, plus ' : '') + 'similar signal strength, non-overlapping presence, similar ping cadence. Heuristic, not definitive.';
+                    return '<div title="' + title + '" style="display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid var(--border-color); cursor: pointer;" onclick="showDevice(\\'' + c.mac + '\\')">' +
+                        '<div style="flex: 1; min-width: 0;">' +
+                        '<div style="font-size: 0.8rem; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">' + primaryName + nameBadge + '</div>' +
+                        '<div style="font-size: 0.65rem; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">' + detail + '</div>' +
+                        '</div>' +
+                        '<div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 0.5rem;">' +
+                        '<div style="width: 50px;">' + bar + '</div>' +
+                        '<span style="font-size: 0.7rem; color: var(--accent-amber); min-width: 32px; text-align: right;">' + c.confidence + '%</span>' +
+                        '</div></div>';
+                }).join('');
+                container.innerHTML = html;
             } catch (error) {
                 container.innerHTML = '<div style="color: var(--text-muted);">Error loading data</div>';
             }
@@ -2073,21 +2228,73 @@ HTML_TEMPLATE = """
         }
 
         function exportData() {
-            const csv = ['MAC,Vendor,Identifier,Class,Sightings,Last_Contact,Group'];
-            const exportDevices = selectedMacs.size > 0
-                ? allDevices.filter(d => selectedMacs.has(d.mac))
-                : allDevices;
-            exportDevices.forEach(d => {
-                const mac = obfuscateMAC(d.mac);
-                const name = d.friendly_name ? obfuscateName(d.friendly_name) : '';
-                csv.push([mac, d.vendor || '', name, d.device_type || '', d.total_sightings, d.last_seen || '', d.group_name || ''].map(csvField).join(','));
-            });
-            const blob = new Blob([csv.join('\\n')], { type: 'text/csv' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = 'bluehood-recon-' + new Date().toISOString().split('T')[0] + '.csv';
-            a.click();
+            const exportBtn = document.getElementById('export-btn');
+            const originalLabel = exportBtn ? exportBtn.textContent : null;
+            try {
+                // A selection or active date filter can reference devices across
+                // pages or outside the current list filter, so pin the export to
+                // those exact MACs; otherwise let the server honor the list filter.
+                let macs = null;
+                if (selectedMacs.size > 0) {
+                    macs = [...selectedMacs];
+                } else if (dateFilteredDevices !== null) {
+                    macs = dateFilteredDevices.map(d => d.mac);
+                }
+                if (macs && macs.length === 0) {
+                    alert('No devices to export for the current view.');
+                    return;
+                }
+
+                // The server streams the CSV directly to disk. Building it in the
+                // browser meant downloading every sighting as one huge JSON blob,
+                // which never finished on a busy sensor.
+                const formatSelect = document.getElementById('export-format');
+                const exportFormat = formatSelect ? formatSelect.value : 'csv';
+                const fields = { screenshot: screenshotMode ? '1' : '0', format: exportFormat };
+                if (macs) {
+                    fields.macs = macs.join(',');
+                } else {
+                    fields.filter = currentFilter;
+                    fields.sort = sortState.column;
+                    fields.direction = getServerSortDirection();
+                    const searchInput = document.getElementById('search');
+                    const searchTerm = searchInput ? searchInput.value.trim() : '';
+                    if (searchTerm) fields.search = searchTerm;
+                }
+
+                // POST through a hidden form + iframe so a large selection isn't
+                // capped by URL length and the page is never navigated away.
+                let iframe = document.getElementById('export-sink');
+                if (!iframe) {
+                    iframe = document.createElement('iframe');
+                    iframe.id = 'export-sink';
+                    iframe.name = 'export-sink';
+                    iframe.style.display = 'none';
+                    document.body.appendChild(iframe);
+                }
+                const form = document.createElement('form');
+                form.method = 'POST';
+                form.action = '/api/devices/export';
+                form.target = 'export-sink';
+                Object.keys(fields).forEach(k => {
+                    const input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = k;
+                    input.value = fields[k];
+                    form.appendChild(input);
+                });
+                document.body.appendChild(form);
+                if (exportBtn) { exportBtn.disabled = true; exportBtn.textContent = 'Exporting...'; }
+                form.submit();
+                setTimeout(() => {
+                    if (form.parentNode) document.body.removeChild(form);
+                    if (exportBtn) { exportBtn.disabled = false; exportBtn.textContent = originalLabel; }
+                }, 2000);
+            } catch (error) {
+                console.error('Export error:', error);
+                alert('Export failed. Please try again.');
+                if (exportBtn) { exportBtn.disabled = false; exportBtn.textContent = originalLabel; }
+            }
         }
 
         // Filter handlers
@@ -2394,7 +2601,12 @@ SETTINGS_TEMPLATE = """
                         <div class="form-group">
                             <label class="form-label">Prune Sightings Older Than (days)</label>
                             <input type="number" class="form-input" id="prune_days" value="0" min="0" max="3650" style="width: 160px;">
-                            <div class="form-hint">Automatically delete sighting records older than this many days. 0 = keep forever.</div>
+                            <div class="form-hint">Automatically prune records older than this many days. 0 = keep forever.</div>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Only Prune Devices With Fewer Than (sightings)</label>
+                            <input type="number" class="form-input" id="prune_min_sightings" value="0" min="0" max="1000000" style="width: 160px;">
+                            <div class="form-hint">When set above 0, pruning removes whole stale devices (and their sightings) that are both older than the age limit and have fewer than this many total sightings. Watched devices are never pruned. 0 = prune old sightings by age only, keeping device records.</div>
                         </div>
                     </div>
                 </div>
@@ -2505,6 +2717,7 @@ SETTINGS_TEMPLATE = """
                 document.getElementById('heartbeat_url').value = data.heartbeat_url || '';
                 document.getElementById('heartbeat_interval').value = data.heartbeat_interval || 300;
                 document.getElementById('prune_days').value = data.prune_days || 0;
+                document.getElementById('prune_min_sightings').value = data.prune_min_sightings || 0;
             } catch (error) { showStatus('Error loading configuration', 'error'); }
         }
 
@@ -2521,6 +2734,7 @@ SETTINGS_TEMPLATE = """
                 heartbeat_url: document.getElementById('heartbeat_url').value,
                 heartbeat_interval: parseInt(document.getElementById('heartbeat_interval').value) || 300,
                 prune_days: parseInt(document.getElementById('prune_days').value) || 0,
+                prune_min_sightings: parseInt(document.getElementById('prune_min_sightings').value) || 0,
             };
         }
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────
+# Bluehood – macOS Install / Uninstall / Reset
+# Installs dependencies into a virtual environment and registers
+# a launchd agent so bluehood starts automatically on login.
+#
+# Usage:
+#   ./install.sh [install]            Install (or upgrade) and auto-start.
+#   ./install.sh uninstall [--purge]  Stop and remove the agent + venv.
+#                                     --purge also deletes data and logs.
+#   ./install.sh reset [--purge]      Uninstall, then reinstall and run.
+#                                     --purge wipes data for a clean reset.
+# ──────────────────────────────────────────────────────────────
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+info()  { printf "${GREEN}[INFO]${NC}  %s\n" "$*"; }
+warn()  { printf "${YELLOW}[WARN]${NC}  %s\n" "$*"; }
+error() { printf "${RED}[ERROR]${NC} %s\n" "$*" >&2; }
+step()  { printf "\n${CYAN}── %s${NC}\n" "$*"; }
+
+usage() {
+    cat <<'USAGE'
+Bluehood – macOS Install / Uninstall / Reset
+
+Usage:
+  ./install.sh [install]            Install (or upgrade) and auto-start.
+  ./install.sh uninstall [--purge]  Stop and remove the agent + venv.
+                                    --purge also deletes data and logs.
+  ./install.sh reset [--purge]      Uninstall, then reinstall and run.
+                                    --purge wipes data for a clean reset.
+USAGE
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="${HOME}/.local/share/bluehood"
+VENV_DIR="${DATA_DIR}/venv"     # Must NOT be under ~/Documents, ~/Desktop, etc.
+                                 # macOS TCC blocks launchd access to those folders.
+LOG_DIR="${HOME}/Library/Logs/bluehood"
+PLIST_LABEL="com.bluehood.daemon"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${PLIST_LABEL}.plist"
+
+# ── Verify macOS ─────────────────────────────────────────────
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    error "This script is for macOS only."
+    exit 1
+fi
+
+# ── Helpers ──────────────────────────────────────────────────
+# Resolve a usable python3 interpreter (>= 3.11).
+find_python() {
+    local candidate
+    for candidate in python3.14 python3.13 python3.12 python3.11 python3; do
+        if command -v "${candidate}" &>/dev/null; then
+            if "${candidate}" -c 'import sys; sys.exit(0 if sys.version_info[:2] >= (3, 11) else 1)' &>/dev/null; then
+                printf '%s' "${candidate}"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+# Stop and unload the launchd agent, then remove the plist.
+remove_agent() {
+    if launchctl list "${PLIST_LABEL}" &>/dev/null 2>&1; then
+        info "Stopping launchd agent …"
+        launchctl unload "${PLIST_PATH}" 2>/dev/null || true
+    fi
+    if [[ -f "${PLIST_PATH}" ]]; then
+        rm -f "${PLIST_PATH}"
+        info "Removed ${PLIST_PATH}"
+    fi
+}
+
+# ── Uninstall ────────────────────────────────────────────────
+do_uninstall() {
+    local purge="${1:-false}"
+
+    step "Uninstalling bluehood"
+    remove_agent
+
+    if [[ -d "${VENV_DIR}" ]]; then
+        rm -rf "${VENV_DIR}"
+        info "Removed venv ${VENV_DIR}"
+    fi
+
+    if [[ "${purge}" == "true" ]]; then
+        [[ -d "${DATA_DIR}" ]] && rm -rf "${DATA_DIR}" && info "Purged data ${DATA_DIR}"
+        [[ -d "${LOG_DIR}"  ]] && rm -rf "${LOG_DIR}"  && info "Purged logs ${LOG_DIR}"
+    else
+        info "Kept data (${DATA_DIR}) and logs (${LOG_DIR}). Use --purge to remove them."
+    fi
+
+    printf "\n${GREEN}✔ Bluehood has been uninstalled.${NC}\n"
+}
+
+# ── Install ──────────────────────────────────────────────────
+do_install() {
+    # ── Step 1: Check Python ────────────────────────────────
+    step "1/5  Checking prerequisites"
+
+    local python_bin
+    if ! python_bin="$(find_python)"; then
+        error "Python 3.11+ not found. Install with:  brew install python@3.12"
+        exit 1
+    fi
+    info "Python $(${python_bin} -c 'import sys; print("%d.%d" % sys.version_info[:2])') (${python_bin}) ✓"
+    info "macOS CoreBluetooth available (no extra drivers needed)."
+
+    # ── Step 2: Create directories ───────────────────────────
+    # Must happen before venv creation since VENV_DIR is inside DATA_DIR.
+    step "2/5  Setting up directories"
+
+    mkdir -p "${DATA_DIR}" "${LOG_DIR}"
+    mkdir -p "$(dirname "${PLIST_PATH}")"
+    info "Data:  ${DATA_DIR}"
+    info "Venv:  ${VENV_DIR}"
+    info "Logs:  ${LOG_DIR}"
+
+    # ── Step 3: Create virtual environment ───────────────────
+    step "3/5  Creating virtual environment"
+
+    if [[ -d "${VENV_DIR}" ]]; then
+        info "Existing venv found – upgrading …"
+    else
+        "${python_bin}" -m venv "${VENV_DIR}"
+        info "Created ${VENV_DIR}"
+    fi
+    "${VENV_DIR}/bin/pip" install --upgrade pip --quiet
+
+    # ── Step 4: Install bluehood ────────────────────────────
+    step "4/5  Installing bluehood package"
+
+    "${VENV_DIR}/bin/pip" install "${SCRIPT_DIR}" --quiet
+
+    # ── Step 5: Install and load launchd agent ───────────────
+    step "5/5  Configuring launchd auto-start"
+
+    remove_agent  # unload + remove any previous version first
+
+    cat > "${PLIST_PATH}" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${PLIST_LABEL}</string>
+
+    <!--
+        Call the venv Python directly — no external bash wrapper needed.
+        The daemon itself waits for the macOS Bluetooth controller to be
+        ready before scanning, avoiding "adapter busy" errors at login.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>${VENV_DIR}/bin/python</string>
+        <string>-m</string>
+        <string>bluehood.daemon</string>
+    </array>
+
+    <!-- WorkingDirectory deliberately set to DATA_DIR (not the
+         project source dir) so launchd doesn't need TCC access to
+         ~/Documents, ~/Desktop, etc. -->
+    <key>WorkingDirectory</key>
+    <string>${DATA_DIR}</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>BLUEHOOD_DATA_DIR</key>
+        <string>${DATA_DIR}</string>
+        <key>PATH</key>
+        <string>${VENV_DIR}/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <!-- Start automatically on login -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart if the process exits with an error -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <!-- Allow more time between crash restarts so the adapter can settle -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>${LOG_DIR}/bluehood.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>${LOG_DIR}/bluehood.stderr.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>
+PLIST
+
+    launchctl load -w "${PLIST_PATH}"
+    info "launchd agent loaded and enabled."
+
+    # ── Verify ───────────────────────────────────────────────
+    # The launcher waits for Bluetooth, so give it extra time
+    info "Waiting for launcher to confirm Bluetooth readiness …"
+    sleep 8
+
+    if launchctl list "${PLIST_LABEL}" &>/dev/null 2>&1; then
+        local pid
+        pid=$(launchctl list "${PLIST_LABEL}" 2>/dev/null | awk 'NR==1{print $1}')
+        if [[ "${pid}" != "-" && -n "${pid}" ]]; then
+            printf "\n${GREEN}✔ Bluehood is running (PID ${pid})!${NC}\n"
+            info "Dashboard: http://localhost:8080"
+        else
+            printf "\n${GREEN}✔ Bluehood agent is registered.${NC}\n"
+            info "The launcher is waiting for Bluetooth – check logs for status."
+        fi
+    else
+        warn "Service may not have started – check logs:"
+        warn "  tail -f ${LOG_DIR}/bluehood.stderr.log"
+    fi
+
+    cat <<EOF
+
+────────────────────────────────────────────
+  Bluehood is installed and will auto-start
+  every time you log in.
+
+  Commands:
+    launchctl stop  ${PLIST_LABEL}
+    launchctl start ${PLIST_LABEL}
+    launchctl list  ${PLIST_LABEL}
+    tail -f ${LOG_DIR}/bluehood.stderr.log
+
+  Uninstall:           ./install.sh uninstall
+  Uninstall + wipe:    ./install.sh uninstall --purge
+  Reset / reinstall:   ./install.sh reset
+
+  Data:  ${DATA_DIR}
+  Logs:  ${LOG_DIR}
+────────────────────────────────────────────
+EOF
+}
+
+# ── Argument parsing ─────────────────────────────────────────
+COMMAND="install"
+PURGE="false"
+for arg in "$@"; do
+    case "${arg}" in
+        install|uninstall|reset) COMMAND="${arg}" ;;
+        --purge)                 PURGE="true" ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            error "Unknown argument: ${arg} (use --help)"
+            exit 1
+            ;;
+    esac
+done
+
+case "${COMMAND}" in
+    install)
+        do_install
+        ;;
+    uninstall)
+        do_uninstall "${PURGE}"
+        ;;
+    reset)
+        do_uninstall "${PURGE}"
+        do_install
+        ;;
+esac


### PR DESCRIPTION


Adds macOS deployment tooling plus a set of device-analysis, storage-management, and cleanup features.

Deployment & runtime
- install.sh: macOS install/uninstall/reset with a launchd agent. The venv lives under ~/.local/share/bluehood (not ~/Documents) to avoid macOS TCC blocking launchd access; supports --purge.
- daemon: wait for the macOS Bluetooth controller to power on before scanning, avoiding "adapter busy" errors when launchd starts the daemon at login. No-op on non-macOS platforms.

Database
- Startup SQLite integrity self-heal: detect and repair index-only corruption automatically.
- prune_stale_devices() + BLUEHOOD_PRUNE_MIN_SIGHTINGS: optionally prune whole stale devices (older than PRUNE_DAYS, seen fewer than N times) instead of only trimming old sighting rows; watched devices are never pruned. Auto-vacuum reclaims disk once enough free pages accumulate.
- Export queries (get_devices_export / get_sightings_for_export).

Analysis
- MAC-rotation linkage ("Likely same device"): heuristically links randomized identifiers that hand off in time, share similar signal strength, and ping at a similar cadence (get_rotation_candidates, get_name_groups).
- Improved device correlation: co-presence plus synchronized arrival/departure (gap/edge windows).

Web
- /api/devices/export (CSV/JSON) streams the whole filtered set, not just the current page, with screenshot-mode MAC/name obfuscation.
- /api/device/{mac}/rotation and /api/name-groups endpoints; UI surfaces the rotation list and richer export.

Docs
- README documents the new env vars, export contents, pruning behavior, and the rotation-linkage feature.